### PR TITLE
fix(api): correct public v2 observations event-table response

### DIFF
--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -22,9 +22,10 @@ service:
         - `io` - input, output
         - `metadata` - metadata (truncated to 200 chars by default, use `expandMetadata` to get full values)
         - `model` - providedModelName, internalModelId, modelParameters
-        - `usage` - usageDetails, costDetails, totalCost
+        - `usage` - usageDetails, costDetails, totalCost, usagePricingTierName
         - `prompt` - promptId, promptName, promptVersion
         - `metrics` - latency, timeToFirstToken
+        - `trace_context` - tags, release, traceName
 
         If not specified, `core` and `basic` field groups are returned.
 
@@ -40,7 +41,7 @@ service:
             type: optional<string>
             docs: |
               Comma-separated list of field groups to include in the response.
-              Available groups: core, basic, time, io, metadata, model, usage, prompt, metrics.
+              Available groups: core, basic, time, io, metadata, model, usage, prompt, metrics, trace_context.
               If not specified, `core` and `basic` field groups are returned.
               Example: "basic,usage,model"
           expandMetadata:

--- a/packages/shared/src/domain/observations.ts
+++ b/packages/shared/src/domain/observations.ts
@@ -116,6 +116,8 @@ export const EventsObservationSchema = ObservationSchema.extend({
   userId: z.string().nullable(),
   sessionId: z.string().nullable(),
   traceName: z.string().nullable(),
+  release: z.string().nullable().optional(),
+  tags: z.array(z.string()).nullable().optional(),
   bookmarked: z.boolean().optional(),
   public: z.boolean().optional(),
 });

--- a/packages/shared/src/server/queries/createGenerationsQuery.ts
+++ b/packages/shared/src/server/queries/createGenerationsQuery.ts
@@ -38,6 +38,9 @@ export type FullEventsObservations = Array<FullEventsObservation>;
 // Public API version of EventsObservation, some fields are omitted because
 // V2 allows clients to specify fields
 export type EventsObservationPublic = Partial<
-  EventsObservation & ObservationPriceFields
+  EventsObservation &
+    ObservationPriceFields & {
+      modelId: string | null;
+    }
 > &
   ObservationCoreFields;

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -117,6 +117,8 @@ export const eventsObservationRecordReadSchema =
     user_id: z.string().nullish(),
     session_id: z.string().nullish(),
     trace_name: z.string().nullish(),
+    release: z.string().nullish(),
+    tags: z.array(z.string()).nullish(),
     bookmarked: z.boolean().optional(),
     public: z.boolean().optional(),
   });

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -102,11 +102,16 @@ async function enrichObservationsWithModelData(
 > {
   // Determine if this is V1 (complete) or V2 (partial) API
   const isV2 = Array.isArray(requestedFields);
+  const effectiveRequestedFields: ObservationFieldGroup[] = isV2
+    ? requestedFields.length === 0
+      ? [...OBSERVATION_FIELD_GROUPS]
+      : requestedFields
+    : [];
 
   // Determine if model enrichment is needed
   // V1 API: always enrich
   // V2 API: only enrich if "model" field group is requested
-  const shouldEnrichModel = !isV2 || requestedFields.includes("model");
+  const shouldEnrichModel = !isV2 || effectiveRequestedFields.includes("model");
 
   // Fetch model data if needed
   const models = shouldEnrichModel
@@ -175,7 +180,9 @@ async function enrichObservationsWithModelData(
         model?.Price?.find((m) => m.usageType === "total")?.price ?? null,
     };
 
-    return enriched;
+    return isV2
+      ? filterObservationFieldsForPublicApi(enriched, effectiveRequestedFields)
+      : enriched;
   });
 }
 
@@ -757,7 +764,7 @@ export const getTraceByIdFromEventsTable = async ({
  * Field groups for selective field fetching in v2 observations API
  *
  * - core: Always included (cursor-required fields)
- * - basic, time, io, metadata, model, usage, prompt, metrics: Optional groups
+ * - basic, time, io, metadata, model, usage, prompt, metrics, trace_context: Optional groups
  */
 export const OBSERVATION_FIELD_GROUPS = [
   "core", // Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type
@@ -766,12 +773,88 @@ export const OBSERVATION_FIELD_GROUPS = [
   "io", // input, output
   "metadata", // metadata
   "model", // providedModelName, internalModelId, modelParameters
-  "usage", // usageDetails, costDetails, totalCost
+  "usage", // usageDetails, costDetails, totalCost, usagePricingTierName
   "prompt", // promptId, promptName, promptVersion
   "metrics", // latency, timeToFirstToken
+  "trace_context", // tags, release, traceName
 ] as const;
 
 export type ObservationFieldGroup = (typeof OBSERVATION_FIELD_GROUPS)[number];
+
+const OBSERVATION_CORE_FIELDS = [
+  "id",
+  "traceId",
+  "startTime",
+  "endTime",
+  "projectId",
+  "parentObservationId",
+  "type",
+] as const;
+
+const OBSERVATION_FIELDS_BY_GROUP: Record<
+  ObservationFieldGroup,
+  readonly string[]
+> = {
+  core: OBSERVATION_CORE_FIELDS,
+  basic: [
+    "name",
+    "level",
+    "statusMessage",
+    "version",
+    "environment",
+    "bookmarked",
+    "public",
+    "userId",
+    "sessionId",
+  ],
+  time: ["completionStartTime", "createdAt", "updatedAt"],
+  io: ["input", "output"],
+  metadata: ["metadata"],
+  model: [
+    "model",
+    "internalModelId",
+    "modelParameters",
+    "modelId",
+    "inputPrice",
+    "outputPrice",
+    "totalPrice",
+  ],
+  usage: [
+    "usageDetails",
+    "costDetails",
+    "providedCostDetails",
+    "inputUsage",
+    "outputUsage",
+    "totalUsage",
+    "inputCost",
+    "outputCost",
+    "totalCost",
+    "usagePricingTierId",
+    "usagePricingTierName",
+  ],
+  prompt: ["promptId", "promptName", "promptVersion"],
+  metrics: ["latency", "timeToFirstToken"],
+  trace_context: ["traceName", "tags", "release"],
+};
+
+export function filterObservationFieldsForPublicApi(
+  observation: EventsObservationPublic,
+  requestedFields: ObservationFieldGroup[],
+): EventsObservationPublic {
+  const effectiveFields =
+    requestedFields.length > 0 ? requestedFields : OBSERVATION_FIELD_GROUPS;
+
+  const allowedFields = new Set<string>(OBSERVATION_CORE_FIELDS);
+  for (const group of effectiveFields) {
+    for (const field of OBSERVATION_FIELDS_BY_GROUP[group]) {
+      allowedFields.add(field);
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(observation).filter(([key]) => allowedFields.has(key)),
+  ) as EventsObservationPublic;
+}
 
 export type PublicApiObservationsQuery = {
   projectId: string;
@@ -868,9 +951,17 @@ export function buildObservationsQueryDoris(opts: PublicApiObservationsQuery): {
       o.usage_details,
       o.cost_details,
       o.total_cost,
+      o.usage_pricing_tier_name,
       o.completion_start_time,
       o.created_at,
       o.updated_at,
+      o.trace_name,
+      o.tags,
+      o.${dq("release")} AS \`release\`,
+      o.bookmarked,
+      o.${dq("public")} AS \`public\`,
+      o.user_id,
+      o.session_id,
       o.event_ts
     FROM events_full o
     ${hasTraceFilter ? `JOIN events_full t ON o.trace_id = t.trace_id AND t.project_id = o.project_id AND t.parent_span_id = ''` : ""}

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -21,14 +21,49 @@ import { logger } from "../logger";
 import type { Model, Price } from "@prisma/client";
 import { parseDorisUTCDateTimeFormat } from "./doris";
 
+/**
+ * Normalize single-object arrays on read. Some stored inputs arrive as
+ * `[{ ... }]` even though ChatML parsing expects `{ ... }`.
+ */
+function unwrapSingleObjectArray(input: unknown): unknown {
+  if (input == null) return input;
+
+  if (
+    Array.isArray(input) &&
+    input.length === 1 &&
+    typeof input[0] === "object" &&
+    input[0] !== null
+  ) {
+    return input[0];
+  }
+
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    if (!trimmed.startsWith("[{") || !trimmed.endsWith("}]")) return input;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (
+        Array.isArray(parsed) &&
+        parsed.length === 1 &&
+        typeof parsed[0] === "object" &&
+        parsed[0] !== null
+      ) {
+        return JSON.stringify(parsed[0]);
+      }
+    } catch {
+      // Not valid JSON — return as-is
+    }
+  }
+
+  return input;
+}
+
 // Helper function to parse timestamps from different backends
 const parseTimestamp = (timestamp: string | Date): Date => {
-  // Only apply special handling for Doris backend
   if (timestamp instanceof Date) {
     return timestamp;
   }
 
-  // Default ClickHouse behavior - always expect string
   if (typeof timestamp === "string") {
     return parseDorisUTCDateTimeFormat(timestamp);
   }
@@ -44,10 +79,24 @@ type ModelWithPrice = Model & { Price: Price[] };
  * @param record - The record to convert (can be null/undefined)
  * @returns A new object with all values converted to numbers, or empty object if input is null/undefined
  */
-function convertNumericRecord(
-  record: Record<string, number> | null | undefined,
+function parseNumericRecord(
+  record: Record<string, number> | string | null | undefined,
 ): Record<string, number> {
   if (!record) return {};
+
+  if (typeof record === "string") {
+    try {
+      const parsed = JSON.parse(record);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parseNumericRecord(parsed as Record<string, number>);
+      }
+    } catch {
+      return {};
+    }
+
+    return {};
+  }
+
   const result: Record<string, number> = {};
   for (const key in record) {
     if (Object.prototype.hasOwnProperty.call(record, key)) {
@@ -57,11 +106,19 @@ function convertNumericRecord(
   return result;
 }
 
+function normalizeBoolean(
+  value: boolean | number | null | undefined,
+): boolean | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  return value !== 0;
+}
+
 /**
- * Validates that all ObservationCoreFields are present and not undefined in a ClickHouse record.
+ * Validates that all ObservationCoreFields are present and not undefined in a Doris record.
  * Throws an error if any required core field is missing.
  *
- * @param record - The partial observation record from ClickHouse to validate
+ * @param record - The partial observation record from Doris to validate
  * @throws Error if any core field is undefined
  * @returns The validated core fields in domain format
  */
@@ -113,10 +170,10 @@ export const enrichObservationWithModelData = (
 };
 
 /**
- * Convert observation record from ClickHouse to domain model
- * Return type depends on input parameters: either complete Observation or Partial<Observation>
+ * Convert observation record from Doris to domain model.
+ * Return type depends on input parameters: either complete Observation or Partial<Observation>.
  *
- * @param record - Raw observation record from ClickHouse
+ * @param record - Raw observation record from Doris
  * @param renderingProps - Rendering options for input/output
  * @param complete - If true, fills missing fields with defaults (V1 API). If false/undefined, returns only present fields (V2 API)
  *
@@ -152,14 +209,17 @@ export function convertObservationPartial(
     );
   }
 
+  const parsedCostDetails = parseNumericRecord(record.cost_details);
+  const parsedUsageDetails = parseNumericRecord(record.usage_details);
+
   const reducedCostDetails =
     record.cost_details !== undefined
-      ? reduceUsageOrCostDetails(record.cost_details)
+      ? reduceUsageOrCostDetails(parsedCostDetails)
       : { input: null, output: null, total: null };
 
   const reducedUsageDetails =
     record.usage_details !== undefined
-      ? reduceUsageOrCostDetails(record.usage_details)
+      ? reduceUsageOrCostDetails(parsedUsageDetails)
       : { input: null, output: null, total: null };
 
   // Core fields are not optional
@@ -200,7 +260,12 @@ export function convertObservationPartial(
 
     // IO fields
     ...(record.input !== undefined && {
-      input: applyInputOutputRendering(record.input, renderingProps),
+      input: applyInputOutputRendering(
+        renderingProps.shouldJsonParse
+          ? unwrapSingleObjectArray(record.input)
+          : record.input,
+        renderingProps,
+      ),
     }),
     ...(record.output !== undefined && {
       output: applyInputOutputRendering(record.output, renderingProps),
@@ -228,19 +293,19 @@ export function convertObservationPartial(
 
     // Usage fields
     ...(record.usage_details !== undefined && {
-      usageDetails: convertNumericRecord(record.usage_details),
+      usageDetails: parsedUsageDetails,
       inputUsage: reducedUsageDetails.input ?? 0,
       outputUsage: reducedUsageDetails.output ?? 0,
       totalUsage: reducedUsageDetails.total ?? 0,
     }),
     ...(record.cost_details !== undefined && {
-      costDetails: convertNumericRecord(record.cost_details),
+      costDetails: parsedCostDetails,
       inputCost: reducedCostDetails.input,
       outputCost: reducedCostDetails.output,
       totalCost: reducedCostDetails.total,
     }),
     ...(record.provided_cost_details !== undefined && {
-      providedCostDetails: convertNumericRecord(record.provided_cost_details),
+      providedCostDetails: parseNumericRecord(record.provided_cost_details),
     }),
 
     // Prompt fields
@@ -370,45 +435,69 @@ export function convertEventsObservation(
   renderingProps: RenderingProps = DEFAULT_RENDERING_PROPS,
   complete: boolean,
 ): EventsObservation | PartialEventsObservation {
-  // Branch based on complete flag to use correct overload
-  const baseObservation = complete
-    ? convertObservationPartial(
-        record as ObservationRecordReadType,
-        renderingProps,
-        true,
-      )
-    : convertObservationPartial(record, renderingProps, false);
+  if (complete) {
+    const baseObservation = convertObservationPartial(
+      record as ObservationRecordReadType,
+      renderingProps,
+      true,
+    );
+
+    return {
+      ...baseObservation,
+      userId: record.user_id ?? null,
+      sessionId: record.session_id ?? null,
+      traceName: record.trace_name ?? null,
+      release: record.release ?? null,
+      tags: record.tags ?? null,
+      bookmarked: normalizeBoolean(record.bookmarked),
+      public: normalizeBoolean(record.public),
+    };
+  }
+
+  const baseObservation = convertObservationPartial(
+    record,
+    renderingProps,
+    false,
+  );
 
   return {
     ...baseObservation,
-    userId: record.user_id ?? null,
-    sessionId: record.session_id ?? null,
-    traceName: record.trace_name ?? null,
-    bookmarked: record.bookmarked,
-    public: record.public,
+    ...(record.user_id !== undefined && { userId: record.user_id }),
+    ...(record.session_id !== undefined && { sessionId: record.session_id }),
+    ...(record.trace_name !== undefined && { traceName: record.trace_name }),
+    ...(record.release !== undefined && { release: record.release }),
+    ...(record.tags !== undefined && { tags: record.tags }),
+    ...(record.bookmarked !== undefined && {
+      bookmarked: normalizeBoolean(record.bookmarked),
+    }),
+    ...(record.public !== undefined && {
+      public: normalizeBoolean(record.public),
+    }),
   };
 }
 
 export const reduceUsageOrCostDetails = (
-  details: Record<string, number> | null | undefined,
+  details: Record<string, number> | string | null | undefined,
 ): {
   input: number | null;
   output: number | null;
   total: number | null;
 } => {
+  const parsedDetails = parseNumericRecord(details);
+
   return {
-    input: Object.entries(details ?? {})
+    input: Object.entries(parsedDetails)
       .filter(([usageType]) => usageType.startsWith("input"))
       .reduce(
         (acc, [, value]) => (acc ?? 0) + Number(value),
         null as number | null, // default to null if no input usage is found
       ),
-    output: Object.entries(details ?? {})
+    output: Object.entries(parsedDetails)
       .filter(([usageType]) => usageType.startsWith("output"))
       .reduce(
         (acc, [, value]) => (acc ?? 0) + Number(value),
         null as number | null, // default to null if no output usage is found
       ),
-    total: Number(details?.total ?? 0),
+    total: Number(parsedDetails.total ?? 0),
   };
 };

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -6,6 +6,7 @@ import {
   getObservationByIdFromEventsTable,
   getObservationsFromEventsTableForPublicApi,
   getObservationsCountFromEventsTableForPublicApi,
+  getObservationsV2FromEventsTableForPublicApi,
   updateEvents,
   getTraceByIdFromEventsTable,
   getObservationsBatchIOFromEventsTable,
@@ -299,6 +300,76 @@ describe("Clickhouse Events Repository Test", () => {
       expect(resultWithoutIO.length).toBeGreaterThanOrEqual(1);
       expect(resultWithIO[0]?.input).toBeDefined();
       expect(resultWithoutIO[0]?.output).toBeDefined();
+    });
+  });
+
+  maybe("getObservationsV2FromEventsTableForPublicApi", () => {
+    it("returns usage pricing tier and trace context field groups", async () => {
+      const traceId = randomUUID();
+      const rootSpanId = randomUUID();
+      const childSpanId = randomUUID();
+      const nowMicro = Date.now() * 1000;
+
+      const rootEvent = createEvent({
+        id: rootSpanId,
+        span_id: rootSpanId,
+        project_id: projectId,
+        trace_id: traceId,
+        parent_span_id: "",
+        type: "GENERATION",
+        name: `root-${traceId}`,
+        trace_name: `trace-${traceId}`,
+        release: "2026.05.15",
+        tags: ["prod", "sdk-js"],
+        public: true,
+        bookmarked: true,
+        user_id: "user-trace-context",
+        session_id: "session-trace-context",
+        usage_pricing_tier_name: "Standard",
+        start_time: nowMicro,
+        end_time: nowMicro + 2_000_000,
+        completion_start_time: nowMicro + 1_000_000,
+      });
+
+      const childEvent = createEvent({
+        id: childSpanId,
+        span_id: childSpanId,
+        project_id: projectId,
+        trace_id: traceId,
+        parent_span_id: rootSpanId,
+        type: "GENERATION",
+        name: `child-${traceId}`,
+        trace_name: `trace-${traceId}`,
+        release: "2026.05.15",
+        tags: ["prod", "sdk-js"],
+        public: true,
+        bookmarked: false,
+        user_id: "user-trace-context",
+        session_id: "session-trace-context",
+        usage_pricing_tier_name: "Standard",
+        start_time: nowMicro + 10_000,
+        end_time: nowMicro + 3_000_000,
+        completion_start_time: nowMicro + 1_500_000,
+      });
+
+      await createEventsCh([rootEvent, childEvent]);
+
+      await waitForExpect(async () => {
+        const result = await getObservationsV2FromEventsTableForPublicApi({
+          projectId,
+          page: 0,
+          limit: 10,
+          traceId,
+          fields: ["core", "usage", "trace_context", "basic"],
+        });
+
+        const observation = result.find((o) => o.id === childSpanId);
+        expect(observation).toBeDefined();
+        expect(observation?.usagePricingTierName).toBe("Standard");
+        expect(observation?.traceName).toBe(`trace-${traceId}`);
+        expect(observation?.release).toBe("2026.05.15");
+        expect(observation?.tags).toEqual(["prod", "sdk-js"]);
+      });
     });
   });
 

--- a/web/src/__tests__/server/repositories/observations-converters.servertest.ts
+++ b/web/src/__tests__/server/repositories/observations-converters.servertest.ts
@@ -1,0 +1,118 @@
+/** @jest-environment node */
+
+import {
+  convertEventsObservation,
+  createEvent,
+} from "@langfuse/shared/src/server";
+
+describe("convertEventsObservation", () => {
+  it("preserves trace context fields on partial v2 conversions", () => {
+    const writeRecord = createEvent({
+      project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      trace_id: "trace-v2-context",
+      span_id: "span-v2-context",
+      id: "span-v2-context",
+      trace_name: "checkout-trace",
+      release: "2026.05.15",
+      tags: ["prod", "checkout"],
+      user_id: "user-123",
+      session_id: "session-123",
+      parent_span_id: "",
+      usage_pricing_tier_name: "Standard",
+    });
+
+    const timestamp = "2026-05-15 10:00:00.000000";
+    const record = {
+      ...writeRecord,
+      start_time: timestamp,
+      end_time: timestamp,
+      created_at: timestamp,
+      updated_at: timestamp,
+      event_ts: timestamp,
+      completion_start_time: timestamp,
+    };
+
+    const observation = convertEventsObservation(
+      {
+        ...record,
+        parent_observation_id: record.parent_span_id,
+      },
+      {
+        truncated: false,
+        shouldJsonParse: false,
+      },
+      false,
+    );
+
+    expect(observation.traceName).toBe("checkout-trace");
+    expect(observation.release).toBe("2026.05.15");
+    expect(observation.tags).toEqual(["prod", "checkout"]);
+    expect(observation.userId).toBe("user-123");
+    expect(observation.sessionId).toBe("session-123");
+  });
+
+  it("parses Doris string maps, normalizes numeric booleans, and preserves raw io strings in v2", () => {
+    const writeRecord = createEvent({
+      project_id: "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      trace_id: "trace-v2-usage",
+      span_id: "span-v2-usage",
+      id: "span-v2-usage",
+      parent_span_id: "",
+      input: JSON.stringify([
+        {
+          role: "user",
+          content: "What is the capital of France?",
+        },
+      ]),
+      output: JSON.stringify([
+        {
+          role: "assistant",
+          content: "Paris",
+        },
+      ]),
+    });
+
+    const timestamp = "2026-05-15 10:00:00.000000";
+    const observation = convertEventsObservation(
+      {
+        ...writeRecord,
+        start_time: timestamp,
+        end_time: timestamp,
+        created_at: timestamp,
+        updated_at: timestamp,
+        event_ts: timestamp,
+        completion_start_time: timestamp,
+        usage_details: '{"input":100,"output":50,"total":150}' as any,
+        cost_details: '{"input":0.1,"output":0.2,"total":0.3}' as any,
+        bookmarked: 0 as any,
+        public: 1 as any,
+        parent_observation_id: writeRecord.parent_span_id,
+      },
+      {
+        truncated: false,
+        shouldJsonParse: false,
+      },
+      false,
+    );
+
+    expect(observation.input).toBe(
+      '[{"role":"user","content":"What is the capital of France?"}]',
+    );
+    expect(observation.output).toBe('[{"role":"assistant","content":"Paris"}]');
+    expect(observation.usageDetails).toEqual({
+      input: 100,
+      output: 50,
+      total: 150,
+    });
+    expect(observation.inputUsage).toBe(100);
+    expect(observation.outputUsage).toBe(50);
+    expect(observation.totalUsage).toBe(150);
+    expect(observation.costDetails).toEqual({
+      input: 0.1,
+      output: 0.2,
+      total: 0.3,
+    });
+    expect(observation.bookmarked).toBe(false);
+    expect(observation.public).toBe(true);
+  });
+});

--- a/web/src/__tests__/server/v2-observations-api-handler.servertest.ts
+++ b/web/src/__tests__/server/v2-observations-api-handler.servertest.ts
@@ -1,0 +1,335 @@
+/** @jest-environment node */
+
+import { createMocks } from "node-mocks-http";
+import Decimal from "decimal.js";
+import { type NextApiRequest, type NextApiResponse } from "next";
+
+jest.mock("@langfuse/shared/src/server", () => {
+  const actual = jest.requireActual("@langfuse/shared/src/server");
+
+  return {
+    __esModule: true,
+    ...actual,
+    getObservationsV2FromEventsTableForPublicApi: jest.fn(),
+    logger: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    },
+    traceException: jest.fn(),
+    contextWithLangfuseProps: jest.fn(() => ({})),
+  };
+});
+
+jest.mock(
+  "../../features/public-api/server/createAuthedProjectAPIRoute",
+  () => {
+    return {
+      __esModule: true,
+      createAuthedProjectAPIRoute:
+        (routeConfig: {
+          querySchema?: { parse: (query: unknown) => unknown };
+          bodySchema?: { parse: (body: unknown) => unknown };
+          fn: (params: {
+            query: unknown;
+            body: unknown;
+            req: NextApiRequest;
+            res: NextApiResponse;
+            auth: {
+              validKey: true;
+              scope: {
+                projectId: string;
+                accessLevel: "project";
+              };
+            };
+          }) => Promise<unknown>;
+          successStatusCode?: number;
+        }) =>
+        async (req: NextApiRequest, res: NextApiResponse) => {
+          const query = routeConfig.querySchema
+            ? routeConfig.querySchema.parse(req.query)
+            : {};
+          const body = routeConfig.bodySchema
+            ? routeConfig.bodySchema.parse(req.body)
+            : {};
+
+          const response = await routeConfig.fn({
+            query,
+            body,
+            req,
+            res,
+            auth: {
+              validKey: true,
+              scope: {
+                projectId: "project-test",
+                accessLevel: "project",
+              },
+            },
+          });
+
+          if (!res.writableEnded) {
+            res.status(routeConfig.successStatusCode ?? 200).json(response);
+          }
+        },
+    };
+  },
+);
+
+jest.mock("../../features/public-api/server/cors", () => ({
+  __esModule: true,
+  cors: (_req: unknown, _res: unknown, next: () => void) => next(),
+  runMiddleware: jest.fn(async () => undefined),
+}));
+
+import * as sharedServer from "@langfuse/shared/src/server";
+import { env } from "@/src/env.mjs";
+import { OBSERVATION_FIELD_GROUPS } from "@/src/features/public-api/types/observations";
+import handler from "@/src/pages/api/public/v2/observations/index";
+
+const mockGetObservationsV2FromEventsTableForPublicApi = jest.mocked(
+  sharedServer.getObservationsV2FromEventsTableForPublicApi,
+);
+
+describe("/api/public/v2/observations handler", () => {
+  const originalFlag = env.LITEFUSE_ENABLE_EVENTS_TABLE_V2_APIS;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      env as unknown as { LITEFUSE_ENABLE_EVENTS_TABLE_V2_APIS: string }
+    ).LITEFUSE_ENABLE_EVENTS_TABLE_V2_APIS = "true";
+  });
+
+  afterAll(() => {
+    (
+      env as unknown as { LITEFUSE_ENABLE_EVENTS_TABLE_V2_APIS: string }
+    ).LITEFUSE_ENABLE_EVENTS_TABLE_V2_APIS = originalFlag;
+  });
+
+  const createReqRes = (query: Record<string, unknown> = {}) =>
+    createMocks({
+      method: "GET",
+      query,
+      headers: {
+        authorization: "Basic dGVzdDp0ZXN0",
+      },
+    });
+
+  it("returns normalized observations with price strings and trace context", async () => {
+    mockGetObservationsV2FromEventsTableForPublicApi.mockResolvedValue([
+      {
+        id: "obs-1",
+        traceId: "trace-1",
+        startTime: new Date("2026-05-15T10:00:00.000Z"),
+        endTime: new Date("2026-05-15T10:00:02.000Z"),
+        projectId: "project-test",
+        parentObservationId: "",
+        type: "GENERATION",
+        usagePricingTierName: "Standard",
+        traceName: "checkout-trace",
+        tags: ["prod", "checkout"],
+        release: "2026.05.15",
+        modelId: "model-1",
+        inputPrice: new Decimal("0.03"),
+        outputPrice: new Decimal("0.06"),
+        totalPrice: new Decimal("0.09"),
+      },
+    ] as Awaited<
+      ReturnType<
+        typeof sharedServer.getObservationsV2FromEventsTableForPublicApi
+      >
+    >);
+
+    const { req, res } = createReqRes({
+      limit: "10",
+      fields: "core,usage,trace_context,model",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(
+      mockGetObservationsV2FromEventsTableForPublicApi,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project-test",
+        limit: 10,
+        fields: ["core", "usage", "trace_context", "model"],
+      }),
+    );
+    expect(res._getJSONData()).toEqual({
+      data: [
+        {
+          id: "obs-1",
+          traceId: "trace-1",
+          startTime: "2026-05-15T10:00:00.000Z",
+          endTime: "2026-05-15T10:00:02.000Z",
+          projectId: "project-test",
+          parentObservationId: null,
+          type: "GENERATION",
+          usagePricingTierName: "Standard",
+          traceName: "checkout-trace",
+          tags: ["prod", "checkout"],
+          release: "2026.05.15",
+          modelId: "model-1",
+          inputPrice: "0.03",
+          outputPrice: "0.06",
+          totalPrice: "0.09",
+        },
+      ],
+      meta: {},
+    });
+  });
+
+  it("returns a cursor based on the last returned item when more than limit items are fetched", async () => {
+    mockGetObservationsV2FromEventsTableForPublicApi.mockResolvedValue([
+      {
+        id: "obs-1",
+        traceId: "trace-1",
+        startTime: new Date("2026-05-15T10:00:00.000Z"),
+        endTime: null,
+        projectId: "project-test",
+        parentObservationId: null,
+        type: "SPAN",
+      },
+      {
+        id: "obs-2",
+        traceId: "trace-2",
+        startTime: new Date("2026-05-15T09:59:00.000Z"),
+        endTime: null,
+        projectId: "project-test",
+        parentObservationId: null,
+        type: "SPAN",
+      },
+    ] as Awaited<
+      ReturnType<
+        typeof sharedServer.getObservationsV2FromEventsTableForPublicApi
+      >
+    >);
+
+    const { req, res } = createReqRes({ limit: "1" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      data: [
+        {
+          id: "obs-1",
+          traceId: "trace-1",
+          startTime: "2026-05-15T10:00:00.000Z",
+          endTime: null,
+          projectId: "project-test",
+          parentObservationId: null,
+          type: "SPAN",
+        },
+      ],
+      meta: {
+        cursor: Buffer.from(
+          JSON.stringify({
+            lastStartTimeTo: "2026-05-15T10:00:00.000Z",
+            lastTraceId: "trace-1",
+            lastId: "obs-1",
+          }),
+        ).toString("base64"),
+      },
+    });
+  });
+
+  it("treats empty string filters as omitted filters", async () => {
+    mockGetObservationsV2FromEventsTableForPublicApi.mockResolvedValue([]);
+
+    const { req, res } = createReqRes({
+      limit: "50",
+      traceId: "",
+      userId: "",
+      name: "",
+      environment: "",
+      version: "",
+      parentObservationId: "",
+      expandMetadata: "",
+      fields: "",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(
+      mockGetObservationsV2FromEventsTableForPublicApi,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: undefined,
+        userId: undefined,
+        name: undefined,
+        environment: undefined,
+        version: undefined,
+        parentObservationId: undefined,
+        fields: [...OBSERVATION_FIELD_GROUPS],
+        expandMetadataKeys: undefined,
+      }),
+    );
+    expect(res._getJSONData()).toEqual({ data: [], meta: {} });
+  });
+
+  it("rejects an empty observation type filter", async () => {
+    const { req, res } = createReqRes({
+      type: "",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().message).toBe("Invalid request data");
+    expect(
+      mockGetObservationsV2FromEventsTableForPublicApi,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects parseIoAsJson=true with 400", async () => {
+    const { req, res } = createReqRes({
+      parseIoAsJson: "true",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().message).toBe("Invalid request data");
+    expect(
+      mockGetObservationsV2FromEventsTableForPublicApi,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid cursor", async () => {
+    const { req, res } = createReqRes({
+      cursor: "not-base64-json",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      message: "Invalid cursor format",
+      error: "InvalidRequestError",
+    });
+    expect(
+      mockGetObservationsV2FromEventsTableForPublicApi,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the v2 feature flag is disabled", async () => {
+    (
+      env as unknown as { LITEFUSE_ENABLE_EVENTS_TABLE_V2_APIS: string }
+    ).LITEFUSE_ENABLE_EVENTS_TABLE_V2_APIS = "false";
+
+    const { req, res } = createReqRes();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      message:
+        "v2 APIs are currently in beta and only available on Langfuse Cloud",
+      error: "LangfuseNotFoundError",
+    });
+  });
+});

--- a/web/src/__tests__/server/v2-observations-api-handler.servertest.ts
+++ b/web/src/__tests__/server/v2-observations-api-handler.servertest.ts
@@ -328,7 +328,7 @@ describe("/api/public/v2/observations handler", () => {
     expect(res._getStatusCode()).toBe(404);
     expect(res._getJSONData()).toEqual({
       message:
-        "v2 APIs are currently in beta and only available on Langfuse Cloud",
+        "v2 APIs are currently in beta and only available on Litefuse Cloud",
       error: "LangfuseNotFoundError",
     });
   });

--- a/web/src/__tests__/server/v2-observations-filter-wiring.servertest.ts
+++ b/web/src/__tests__/server/v2-observations-filter-wiring.servertest.ts
@@ -1,0 +1,161 @@
+/** @jest-environment node */
+
+/**
+ * Bug fix coverage: simple-param filters on /api/public/v2/observations
+ * (fromStartTime, toStartTime, traceId, userId, name, type, level,
+ * parentObservationId, version, environment) were silently dropped by
+ * buildObservationsQueryDoris because the rest-spread `...filterParams`
+ * was extracted but never applied. This test inspects the generated SQL
+ * to confirm they now reach the WHERE clause via deriveFilters.
+ *
+ * Doris filters inline literal values (with single-quote escaping) into the
+ * SQL string rather than using parameterized queries — assertions therefore
+ * match against the SQL text. Only projectId uses placeholder syntax via
+ * the hardcoded WHERE clause.
+ */
+
+import {
+  buildObservationsQueryDoris,
+  filterObservationFieldsForPublicApi,
+  type PublicApiObservationsQuery,
+} from "@langfuse/shared/src/server";
+
+const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+const baseOpts = {
+  projectId,
+  page: 0,
+  limit: 50,
+} satisfies PublicApiObservationsQuery;
+
+describe("buildObservationsQueryDoris — simple-param filter wiring", () => {
+  it("emits a start_time lower bound for fromStartTime", () => {
+    const fromStartTime = "2026-05-22T00:00:00.000Z";
+    const { baseQuery } = buildObservationsQueryDoris({
+      ...baseOpts,
+      fromStartTime,
+    });
+
+    expect(baseQuery).toMatch(/o\.\s*start_time\s*>=\s*'2026-05-22 00:00:00/);
+  });
+
+  it("emits a start_time upper bound for toStartTime", () => {
+    const toStartTime = "2026-05-22T01:00:00.000Z";
+    const { baseQuery } = buildObservationsQueryDoris({
+      ...baseOpts,
+      toStartTime,
+    });
+
+    expect(baseQuery).toMatch(/o\.\s*start_time\s*<\s*'2026-05-22 01:00:00/);
+  });
+
+  it("emits a trace_id equality on observations side without joining traces", () => {
+    const traceId = "trace-abc";
+    const { baseQuery } = buildObservationsQueryDoris({
+      ...baseOpts,
+      traceId,
+    });
+
+    expect(baseQuery).toMatch(/o\.\s*trace_id\s*=\s*'trace-abc'/);
+    expect(baseQuery).not.toMatch(/JOIN\s+events_full\s+t/i);
+  });
+
+  it("joins events_full as t and filters t.user_id when userId is set", () => {
+    const userId = "user-xyz";
+    const { baseQuery } = buildObservationsQueryDoris({
+      ...baseOpts,
+      userId,
+    });
+
+    expect(baseQuery).toMatch(/JOIN\s+events_full\s+t\b/i);
+    expect(baseQuery).toMatch(/t\.\s*parent_span_id\s*=\s*''/);
+    expect(baseQuery).toMatch(/t\.\s*user_id\s*=\s*'user-xyz'/);
+  });
+
+  it("emits name + type + level + version equalities on observations", () => {
+    const { baseQuery } = buildObservationsQueryDoris({
+      ...baseOpts,
+      name: "my-span",
+      type: "GENERATION",
+      level: "ERROR",
+      version: "v1.2.3",
+    });
+
+    expect(baseQuery).toMatch(/o\.\s*name\s*=\s*'my-span'/);
+    expect(baseQuery).toMatch(/o\.\s*type\s*=\s*'GENERATION'/);
+    expect(baseQuery).toMatch(/o\.\s*level\s*=\s*'ERROR'/);
+    expect(baseQuery).toMatch(/o\.\s*version\s*=\s*'v1\.2\.3'/);
+  });
+
+  it("emits parent_span_id equality for parentObservationId", () => {
+    const { baseQuery } = buildObservationsQueryDoris({
+      ...baseOpts,
+      parentObservationId: "parent-span-123",
+    });
+
+    expect(baseQuery).toMatch(/o\.\s*parent_span_id\s*=\s*'parent-span-123'/);
+  });
+
+  it("emits environment equality on observations side", () => {
+    const { baseQuery } = buildObservationsQueryDoris({
+      ...baseOpts,
+      environment: "production",
+    });
+
+    expect(baseQuery).toMatch(/o\.\s*environment\s*=\s*'production'/);
+  });
+
+  it("retains projectId filter and does not JOIN when no simple filters are passed", () => {
+    const { baseQuery, params } = buildObservationsQueryDoris(baseOpts);
+
+    expect(baseQuery).toMatch(/o\.\s*project_id\s*=\s*\{projectId:\s*String\}/);
+    expect(baseQuery).not.toMatch(/JOIN\s+events_full\s+t/i);
+    expect(params.projectId).toBe(projectId);
+  });
+
+  it("quotes reserved aliases for release and public in the select list", () => {
+    const { baseQuery } = buildObservationsQueryDoris(baseOpts);
+
+    expect(baseQuery).toMatch(/o\.`release`\s+AS\s+`release`/);
+    expect(baseQuery).toMatch(/o\.`public`\s+AS\s+`public`/);
+  });
+
+  it("escapes single quotes in simple filter values", () => {
+    const { baseQuery } = buildObservationsQueryDoris({
+      ...baseOpts,
+      name: "abc'def",
+    });
+
+    expect(baseQuery).toMatch(/o\.\s*name\s*=\s*'abc''def'/);
+  });
+
+  it("returns only core fields when fields=core is requested", () => {
+    const filtered = filterObservationFieldsForPublicApi(
+      {
+        id: "obs-1",
+        traceId: "trace-1",
+        startTime: new Date("2026-05-15T10:00:00.000Z"),
+        endTime: null,
+        projectId,
+        parentObservationId: null,
+        type: "GENERATION",
+        name: "should-be-removed",
+        input: "should-be-removed",
+        usageDetails: { input: 100, output: 50, total: 150 },
+        traceName: "should-be-removed",
+        modelId: "should-be-removed",
+      },
+      ["core"],
+    );
+
+    expect(filtered).toEqual({
+      id: "obs-1",
+      traceId: "trace-1",
+      startTime: new Date("2026-05-15T10:00:00.000Z"),
+      endTime: null,
+      projectId,
+      parentObservationId: null,
+      type: "GENERATION",
+    });
+  });
+});

--- a/web/src/__tests__/server/v2-observations-response-schema.servertest.ts
+++ b/web/src/__tests__/server/v2-observations-response-schema.servertest.ts
@@ -1,0 +1,34 @@
+/** @jest-environment node */
+
+import { GetObservationsV2Response } from "@/src/features/public-api/types/observations";
+
+describe("GetObservationsV2Response", () => {
+  it("accepts usage pricing tier and trace context fields", () => {
+    const parsed = GetObservationsV2Response.parse({
+      data: [
+        {
+          id: "obs-1",
+          traceId: "trace-1",
+          startTime: "2026-05-15T10:00:00.000Z",
+          endTime: "2026-05-15T10:00:02.000Z",
+          projectId: "project-1",
+          parentObservationId: null,
+          type: "GENERATION",
+          usagePricingTierName: "Standard",
+          traceName: "checkout-trace",
+          tags: ["prod", "checkout"],
+          release: "2026.05.15",
+          inputPrice: "0.03",
+          outputPrice: "0.06",
+          totalPrice: "0.09",
+        },
+      ],
+      meta: {},
+    });
+
+    expect(parsed.data[0].usagePricingTierName).toBe("Standard");
+    expect(parsed.data[0].traceName).toBe("checkout-trace");
+    expect(parsed.data[0].tags).toEqual(["prod", "checkout"]);
+    expect(parsed.data[0].release).toBe("2026.05.15");
+  });
+});

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -407,6 +407,7 @@ const APIObservationV2 = z
     usageDetails: z.record(z.string(), z.number().nonnegative()).optional(),
     costDetails: z.record(z.string(), z.number().nonnegative()).optional(),
     totalCost: z.number().nullable().optional(),
+    usagePricingTierName: z.string().nullable().optional(),
 
     // Prompt fields (field group: prompt)
     promptId: z.string().nullable().optional(),
@@ -419,6 +420,14 @@ const APIObservationV2 = z
 
     // Enrichment fields
     modelId: z.string().nullable().optional(),
+    inputPrice: z.string().nullable().optional(),
+    outputPrice: z.string().nullable().optional(),
+    totalPrice: z.string().nullable().optional(),
+
+    // Trace context fields (field group: trace_context)
+    traceName: z.string().nullable().optional(),
+    tags: z.array(z.string()).optional(),
+    release: z.string().nullable().optional(),
   })
   .passthrough();
 

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -8,8 +8,28 @@ import { env } from "@/src/env.mjs";
 import {
   GetObservationsV2Query,
   GetObservationsV2Response,
+  OBSERVATION_FIELD_GROUPS,
   encodeCursor,
 } from "@/src/features/public-api/types/observations";
+
+const normalizeOptionalString = (value: string | null | undefined) => {
+  if (typeof value !== "string") {
+    return value ?? undefined;
+  }
+
+  return value.trim() === "" ? undefined : value;
+};
+
+const normalizeOptionalStringOrArray = (
+  value: string | string[] | null | undefined,
+) => {
+  if (Array.isArray(value)) {
+    const filtered = value.filter((item) => item.trim() !== "");
+    return filtered.length > 0 ? filtered : undefined;
+  }
+
+  return normalizeOptionalString(value);
+};
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -31,16 +51,16 @@ export default withMiddlewares({
         projectId: auth.scope.projectId,
         page: 0, // v2 doesn't use page-based pagination
         limit: query.limit,
-        traceId: query.traceId ?? undefined,
-        userId: query.userId ?? undefined,
+        traceId: normalizeOptionalString(query.traceId),
+        userId: normalizeOptionalString(query.userId),
         level: query.level ?? undefined,
-        name: query.name ?? undefined,
+        name: normalizeOptionalString(query.name),
         type: query.type ?? undefined,
-        environment: query.environment ?? undefined,
-        parentObservationId: query.parentObservationId ?? undefined,
+        environment: normalizeOptionalStringOrArray(query.environment),
+        parentObservationId: normalizeOptionalString(query.parentObservationId),
         fromStartTime: query.fromStartTime ?? undefined,
         toStartTime: query.toStartTime ?? undefined,
-        version: query.version ?? undefined,
+        version: normalizeOptionalString(query.version),
         advancedFilters: query.filter,
         cursor: query.cursor ?? undefined,
         fields: fieldGroups,
@@ -50,19 +70,37 @@ export default withMiddlewares({
       // Fetch observations from events table with field groups applied at query time
       const items = await getObservationsV2FromEventsTableForPublicApi({
         ...filterProps,
-        fields: filterProps.fields ?? [], // V2 requires fields array
+        fields: filterProps.fields ?? [...OBSERVATION_FIELD_GROUPS],
       });
 
       // Determine if there are more results (we fetched limit+1)
       const hasMore = items.length > query.limit;
       const dataToReturn = hasMore ? items.slice(0, query.limit) : items;
 
-      // Convert empty parent_observation_id to null for consistency with v1
+      // Normalize wire format for v2:
+      // - empty parent_observation_id -> null (v1 parity)
+      // - Decimal price fields -> string (stable serialized contract)
       const transformedItems = dataToReturn.map((item) => {
-        if (item.parentObservationId === "") {
-          return { ...item, parentObservationId: null };
-        }
-        return item;
+        const { inputPrice, outputPrice, totalPrice, modelId, ...rest } = item;
+
+        return {
+          ...rest,
+          parentObservationId:
+            item.parentObservationId === "" ? null : item.parentObservationId,
+          tags: item.tags ?? undefined,
+          ...(Object.prototype.hasOwnProperty.call(item, "modelId") && {
+            modelId: modelId ?? null,
+          }),
+          ...(Object.prototype.hasOwnProperty.call(item, "inputPrice") && {
+            inputPrice: inputPrice?.toString() ?? null,
+          }),
+          ...(Object.prototype.hasOwnProperty.call(item, "outputPrice") && {
+            outputPrice: outputPrice?.toString() ?? null,
+          }),
+          ...(Object.prototype.hasOwnProperty.call(item, "totalPrice") && {
+            totalPrice: totalPrice?.toString() ?? null,
+          }),
+        };
       });
 
       // Generate cursor if there are more results


### PR DESCRIPTION
- parse Doris stringified usage/cost maps before reducing usage fields
- preserve raw v2 input/output payloads instead of unwrapping single-item arrays
- normalize numeric bookmarked/public values to booleans
- enforce v2 field-group filtering, including trace_context and pricing fields
- include trace context and usage pricing tier fields in API schema and Fern docs
- add handler, converter, repository, and response-schema regression coverage

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Summary

This PR fixes `/api/public/v2/observations` when reading from the events table.

The main issues were:
- Doris `usage_details` / `cost_details` could come back as JSON strings, which caused `usageDetails` to be serialized into
numeric-key garbage and `inputUsage` / `outputUsage` / `totalUsage` to be computed as `0`
- raw v2 `input` payloads were being unwrapped from single-item arrays, so the wire format no longer matched the stored Doris
value
- `bookmarked` / `public` were returned as `0` / `1` instead of booleans
- `fields=core` did not actually filter the response down to core fields
- trace-context and pricing-related fields were not fully wired through the schema and docs

## Changes

- parse Doris stringified usage/cost maps before usage reduction and response shaping
- preserve raw v2 `input` / `output` values when `shouldJsonParse=false`
- normalize numeric booleans from Doris into API booleans
- add field-group filtering for v2 public observations responses
- extend field groups to include `trace_context`
- return `usagePricingTierName`, `traceName`, `tags`, `release`, and price fields in the v2 schema
- normalize empty optional string filters in the API handler
- serialize decimal price fields to strings in the v2 response
- update Fern docs for the expanded v2 observations field groups
- add regression tests for converters, handler behavior, schema acceptance, filter wiring, and Doris-backed repository behavior

## Impacted Packages

- `web`
- `packages/shared`
- `fern`

## Verification

Executed:
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter web run typecheck`
- `pnpm --filter web run test --testPathPatterns='observations-converters.servertest.ts|v2-observations-api-
handler.servertest.ts|v2-observations-filter-wiring.servertest.ts|v2-observations-response-schema.servertest.ts'`

Live validation:
- inserted 4 fresh OTel traces into local `localhost:3000`
- compared `/api/public/v2/observations` against Doris `events_full`
- confirmed:
  - `usageDetails` matches Doris values
  - `inputUsage` / `outputUsage` / `totalUsage` are computed correctly
  - raw `input` / `output` match Doris payload shape
  - `bookmarked` / `public` are booleans
  - `fields=core` returns only core fields

## Notes

This PR only changes the v2 observations read path from the events table and related contract/tests.


<!-- Please provide a loom video for visual changes to speed up reviews
Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/selectdb/langfuse-doris/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

