### PR TITLE
feat(llm): modularize qwen and minimax LLM compatibility handlers

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -24,6 +24,7 @@ export * from "./llm/fetchLLMCompletion";
 export * from "./llm/errors";
 export * from "./llm/utils";
 export * from "./llm/types";
+export * from "./llm/handlers";
 export * from "./llm/compileChatMessages";
 export * from "./llm/testModelCall";
 export * from "./llm/getInternalTracingHandler";

--- a/packages/shared/src/server/llm/__tests__/providerHandlers.unit.test.ts
+++ b/packages/shared/src/server/llm/__tests__/providerHandlers.unit.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAnthropicCompatibleProviderHandler,
+  resolveOpenAICompatibleProviderHandler,
+  processAnthropicCompatibleBaseURL,
+  stripThinkingFromObject,
+  stripThinkingFromText,
+} from "../handlers";
+import { LLMAdapter } from "../types";
+
+describe("OpenAI-compatible provider handlers", () => {
+  it("returns null for non-OpenAI adapters", () => {
+    const handler = resolveOpenAICompatibleProviderHandler({
+      adapter: LLMAdapter.Anthropic,
+      provider: "qwen",
+      baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    });
+
+    expect(handler).toBeNull();
+  });
+
+  it("disables thinking by default for Qwen and uses functionCalling for structured output", () => {
+    const handler = resolveOpenAICompatibleProviderHandler({
+      adapter: LLMAdapter.OpenAI,
+      provider: "qwen",
+      baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    });
+
+    expect(handler?.id).toBe("qwen-openai");
+
+    const config = handler?.buildConfig({
+      baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      modelName: "qwen3.6-flash",
+      providerOptions: undefined,
+      hasStructuredOutput: true,
+    });
+
+    expect(config).toEqual({
+      baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      modelKwargs: {
+        enable_thinking: false,
+      },
+      structuredOutput: {
+        method: "functionCalling",
+      },
+    });
+  });
+
+  it("preserves explicit Qwen thinking overrides", () => {
+    const handler = resolveOpenAICompatibleProviderHandler({
+      adapter: LLMAdapter.OpenAI,
+      provider: "qwen",
+      baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    });
+
+    const config = handler?.buildConfig({
+      baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      modelName: "qwen3.6-flash",
+      providerOptions: {
+        enable_thinking: true,
+      },
+      hasStructuredOutput: false,
+    });
+
+    expect(config?.modelKwargs).toEqual({
+      enable_thinking: true,
+    });
+  });
+
+  it("disables thinking by default for Qwen Anthropic-compatible endpoints", () => {
+    const handler = resolveAnthropicCompatibleProviderHandler({
+      adapter: LLMAdapter.Anthropic,
+      provider: "qwen",
+      baseURL: "https://dashscope.aliyuncs.com/apps/anthropic/v1/messages",
+    });
+
+    expect(handler?.id).toBe("qwen-anthropic");
+
+    const config = handler?.buildConfig({
+      baseURL: "https://dashscope.aliyuncs.com/apps/anthropic/v1/messages",
+      modelName: "qwen3.6-flash",
+      providerOptions: undefined,
+      hasStructuredOutput: true,
+    });
+
+    expect(config?.baseURL).toBe(
+      "https://dashscope.aliyuncs.com/apps/anthropic",
+    );
+    expect(config?.invocationKwargs).toEqual({
+      thinking: { type: "disabled" },
+    });
+    expect(config?.thinkingBlockTypes).toBeUndefined();
+  });
+
+  it("marks Qwen Anthropic as thinking-capable when explicitly enabled", () => {
+    const handler = resolveAnthropicCompatibleProviderHandler({
+      adapter: LLMAdapter.Anthropic,
+      provider: "qwen",
+      baseURL: "https://dashscope.aliyuncs.com/apps/anthropic",
+    });
+
+    const config = handler?.buildConfig({
+      baseURL: "https://dashscope.aliyuncs.com/apps/anthropic",
+      modelName: "qwen3.6-flash",
+      providerOptions: {
+        thinking: { type: "enabled", budget_tokens: 256 },
+      },
+      hasStructuredOutput: false,
+    });
+
+    expect(config?.invocationKwargs).toEqual({
+      thinking: { type: "enabled", budget_tokens: 256 },
+    });
+    expect(Array.from(config?.thinkingBlockTypes ?? [])).toEqual(["thinking"]);
+  });
+
+  it("enables reasoning_split by default for MiniMax, uses functionCalling for structured output, and strips thinking tags from text", () => {
+    const handler = resolveOpenAICompatibleProviderHandler({
+      adapter: LLMAdapter.OpenAI,
+      provider: "minimax",
+      baseURL: "https://api.minimaxi.com/v1",
+    });
+
+    expect(handler?.id).toBe("minimax-openai");
+
+    const config = handler?.buildConfig({
+      baseURL: "https://api.minimaxi.com/v1",
+      modelName: "MiniMax-M2.7",
+      providerOptions: undefined,
+      hasStructuredOutput: true,
+    });
+
+    expect(config).toEqual({
+      baseURL: "https://api.minimaxi.com/v1",
+      modelKwargs: {
+        reasoning_split: true,
+      },
+      structuredOutput: {
+        method: "functionCalling",
+      },
+    });
+
+    expect(
+      handler?.normalizeTextCompletion?.("<think>reasoning</think>\n\n4"),
+    ).toBe("4");
+  });
+
+  it("preserves explicit MiniMax reasoning_split overrides", () => {
+    const handler = resolveOpenAICompatibleProviderHandler({
+      adapter: LLMAdapter.OpenAI,
+      provider: "minimax",
+      baseURL: "https://api.minimaxi.com/v1",
+    });
+
+    const config = handler?.buildConfig({
+      baseURL: "https://api.minimaxi.com/v1",
+      modelName: "MiniMax-M2.7",
+      providerOptions: {
+        reasoning_split: false,
+      },
+      hasStructuredOutput: false,
+    });
+
+    expect(config?.modelKwargs).toEqual({
+      reasoning_split: false,
+    });
+  });
+
+  it("disables thinking for MiniMax Anthropic structured output on M2 models", () => {
+    const handler = resolveAnthropicCompatibleProviderHandler({
+      adapter: LLMAdapter.Anthropic,
+      provider: "minimax",
+      baseURL: "https://api.minimax.io/anthropic/v1/messages",
+    });
+
+    expect(handler?.id).toBe("minimax-anthropic");
+
+    const config = handler?.buildConfig({
+      baseURL: "https://api.minimax.io/anthropic/v1/messages",
+      modelName: "MiniMax-M2.7",
+      providerOptions: undefined,
+      hasStructuredOutput: true,
+    });
+
+    expect(config?.baseURL).toBe("https://api.minimax.io/anthropic");
+    expect(config?.invocationKwargs).toEqual({
+      thinking: { type: "disabled" },
+    });
+    expect(config?.structuredOutput).toEqual({
+      method: "functionCalling",
+    });
+    expect(config?.thinkingBlockTypes).toBeUndefined();
+  });
+
+  it("keeps MiniMax Anthropic M2 models thinking-capable for non-structured calls", () => {
+    const handler = resolveAnthropicCompatibleProviderHandler({
+      adapter: LLMAdapter.Anthropic,
+      provider: "minimax",
+      baseURL: "https://api.minimax.io/anthropic/v1/messages",
+    });
+
+    const config = handler?.buildConfig({
+      baseURL: "https://api.minimax.io/anthropic/v1/messages",
+      modelName: "MiniMax-M2.7",
+      providerOptions: undefined,
+      hasStructuredOutput: false,
+    });
+
+    expect(config?.baseURL).toBe("https://api.minimax.io/anthropic");
+    expect(config?.invocationKwargs).toEqual({});
+    expect(Array.from(config?.thinkingBlockTypes ?? [])).toEqual(["thinking"]);
+  });
+
+  it("disables thinking by default for MiniMax Anthropic M3 models", () => {
+    const handler = resolveAnthropicCompatibleProviderHandler({
+      adapter: LLMAdapter.Anthropic,
+      provider: "minimax",
+      baseURL: "https://api.minimax.io/anthropic",
+    });
+
+    const config = handler?.buildConfig({
+      baseURL: "https://api.minimax.io/anthropic",
+      modelName: "MiniMax-M3",
+      providerOptions: undefined,
+      hasStructuredOutput: false,
+    });
+
+    expect(config?.invocationKwargs).toEqual({
+      thinking: { type: "disabled" },
+    });
+    expect(config?.thinkingBlockTypes).toBeUndefined();
+  });
+
+  it("strips MiniMax thinking tags from tool-call content without touching tool_calls", () => {
+    const handler = resolveOpenAICompatibleProviderHandler({
+      adapter: LLMAdapter.OpenAI,
+      provider: "minimax",
+      baseURL: "https://api.minimaxi.com/v1",
+    });
+
+    const normalized = handler?.normalizeToolCallResponse?.({
+      content:
+        "<think>The user wants to know the weather in Paris.</think>\n\n",
+      tool_calls: [
+        {
+          id: "call_123",
+          name: "get_weather",
+          args: {
+            location: "Paris",
+          },
+        },
+      ],
+    });
+
+    expect(normalized).toEqual({
+      content: "",
+      tool_calls: [
+        {
+          id: "call_123",
+          name: "get_weather",
+          args: {
+            location: "Paris",
+          },
+        },
+      ],
+    });
+  });
+
+  it("cleans nested thinking tags from structured outputs", () => {
+    expect(
+      stripThinkingFromObject({
+        answer: "<think>reasoning</think>4",
+        nested: {
+          reasoning: "prefix<think>hidden</think>suffix",
+        },
+      }),
+    ).toEqual({
+      answer: "4",
+      nested: {
+        reasoning: "prefixsuffix",
+      },
+    });
+  });
+
+  it("normalizes generic OpenAI-compatible base URLs", () => {
+    const handler = resolveOpenAICompatibleProviderHandler({
+      adapter: LLMAdapter.OpenAI,
+      provider: "custom",
+      baseURL: "https://proxy.example.com/openai/{model}",
+    });
+
+    const templatedConfig = handler?.buildConfig({
+      baseURL: "https://proxy.example.com/openai/{model}",
+      modelName: "custom-model",
+      providerOptions: undefined,
+      hasStructuredOutput: false,
+    });
+
+    const miniMaxLegacyConfig = handler?.buildConfig({
+      baseURL: "https://api.minimax.example.com/v1/text/chatcompletion_v2",
+      modelName: "custom-model",
+      providerOptions: undefined,
+      hasStructuredOutput: false,
+    });
+
+    expect(templatedConfig?.baseURL).toBe(
+      "https://proxy.example.com/openai/custom-model",
+    );
+    expect(miniMaxLegacyConfig?.baseURL).toBe(
+      "https://api.minimax.example.com",
+    );
+    expect(stripThinkingFromText("before<think>hidden</think>after")).toBe(
+      "beforeafter",
+    );
+  });
+
+  it("normalizes Anthropic-compatible messages endpoints", () => {
+    expect(
+      processAnthropicCompatibleBaseURL(
+        "https://dashscope.aliyuncs.com/apps/anthropic/v1/messages",
+      ),
+    ).toBe("https://dashscope.aliyuncs.com/apps/anthropic");
+
+    expect(
+      processAnthropicCompatibleBaseURL(
+        "https://api.minimax.io/anthropic/v1/messages",
+      ),
+    ).toBe("https://api.minimax.io/anthropic");
+  });
+});

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -37,6 +37,12 @@ import { decrypt } from "../../encryption";
 import { decryptAndParseExtraHeaders } from "./utils";
 import { logger } from "../logger";
 import { LLMCompletionError } from "./errors";
+import {
+  resolveAnthropicCompatibleProviderHandler,
+  resolveOpenAICompatibleProviderHandler,
+  type AnthropicCompatibleProviderConfig,
+  type OpenAICompatibleProviderConfig,
+} from "./handlers";
 
 export type CompletionWithReasoning = { text: string; reasoning?: string };
 
@@ -48,40 +54,6 @@ const THINKING_BLOCK_TYPES: Partial<Record<LLMAdapter, Set<string>>> = {
 
 function getThinkingBlockTypes(adapter: LLMAdapter): Set<string> | undefined {
   return THINKING_BLOCK_TYPES[adapter];
-}
-
-// Providers that return thinking/reasoning content in their responses.
-// These providers corrupt JSON parsing when using json_object mode for structured output,
-// so we must force function calling mode instead.
-const PROVIDERS_WITH_THINKING_CONTENT = new Set(["minimax"]);
-
-function hasThinkingContent(provider: string | undefined): boolean {
-  return provider ? PROVIDERS_WITH_THINKING_CONTENT.has(provider) : false;
-}
-
-// Regex to strip thinking tags from string content
-// Matches: <think>(anything)</think> or <think>(anything)内科
-const THINKING_TAG_REGEX = /<think>[\s\S]*?<\/think>/gi;
-
-/**
- * Recursively strips thinking content from an object.
- * Used for providers (like MiniMax) that include thinking tags in JSON string fields.
- */
-function stripThinkingFromObject(obj: unknown): unknown {
-  if (typeof obj === "string") {
-    return obj.replace(THINKING_TAG_REGEX, "");
-  }
-  if (Array.isArray(obj)) {
-    return obj.map(stripThinkingFromObject);
-  }
-  if (obj !== null && typeof obj === "object") {
-    const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(obj)) {
-      result[key] = stripThinkingFromObject(value);
-    }
-    return result;
-  }
-  return obj;
 }
 
 const PROVIDERS_WITH_REQUIRED_USER_MESSAGE = [
@@ -178,6 +150,20 @@ export async function fetchLLMCompletion(
   const { baseURL } = llmConnection;
   const apiKey = decrypt(llmConnection.secretKey); // the apiKey must never be printed to the console
   const extraHeaders = decryptAndParseExtraHeaders(llmConnection.extraHeaders);
+  const openAICompatibleProviderHandler =
+    resolveOpenAICompatibleProviderHandler({
+      adapter: modelParams.adapter,
+      provider: modelParams.provider,
+      baseURL,
+    });
+  const anthropicCompatibleProviderHandler =
+    resolveAnthropicCompatibleProviderHandler({
+      adapter: modelParams.adapter,
+      provider: modelParams.provider,
+      baseURL,
+    });
+  const activeProviderHandler =
+    openAICompatibleProviderHandler ?? anthropicCompatibleProviderHandler;
 
   let finalCallbacks: BaseCallbackHandler[] | undefined = callbacks ?? [];
   let processTracedEvents: ProcessTracedEvents = () => Promise.resolve();
@@ -264,9 +250,23 @@ export async function fetchLLMCompletion(
   const proxyUrl = env.HTTPS_PROXY;
   const proxyDispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
   const timeoutMs = env.LITEFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS;
+  let openAICompatibleProviderConfig:
+    | OpenAICompatibleProviderConfig
+    | undefined;
+  let anthropicCompatibleProviderConfig:
+    | AnthropicCompatibleProviderConfig
+    | undefined;
 
   let chatModel: ChatOpenAI | ChatAnthropic | ChatGoogleGenerativeAI;
   if (modelParams.adapter === LLMAdapter.Anthropic) {
+    anthropicCompatibleProviderConfig =
+      anthropicCompatibleProviderHandler?.buildConfig({
+        baseURL,
+        modelName: modelParams.model,
+        providerOptions: modelParams.providerOptions,
+        hasStructuredOutput: params.structuredOutputSchema != null,
+      });
+
     const isClaude45Family =
       modelParams.model?.includes("claude-sonnet-4-5") ||
       modelParams.model?.includes("claude-opus-4-1") ||
@@ -276,7 +276,8 @@ export async function fetchLLMCompletion(
 
     const chatOptions: ChatAnthropicInput = {
       anthropicApiKey: apiKey,
-      anthropicApiUrl: baseURL ?? undefined,
+      anthropicApiUrl:
+        anthropicCompatibleProviderConfig?.baseURL ?? baseURL ?? undefined,
       model: modelParams.model,
       maxTokens: modelParams.max_tokens,
       callbacks: finalCallbacks,
@@ -290,7 +291,9 @@ export async function fetchLLMCompletion(
       },
       temperature: modelParams.temperature,
       topP: modelParams.top_p,
-      invocationKwargs: modelParams.providerOptions,
+      invocationKwargs:
+        anthropicCompatibleProviderConfig?.invocationKwargs ??
+        modelParams.providerOptions,
     };
 
     chatModel = new ChatAnthropic(chatOptions);
@@ -317,10 +320,13 @@ export async function fetchLLMCompletion(
       }
     }
   } else if (modelParams.adapter === LLMAdapter.OpenAI) {
-    const processedBaseURL = processOpenAIBaseURL({
-      url: baseURL,
-      modelName: modelParams.model,
-    });
+    openAICompatibleProviderConfig =
+      openAICompatibleProviderHandler?.buildConfig({
+        baseURL,
+        modelName: modelParams.model,
+        providerOptions: modelParams.providerOptions,
+        hasStructuredOutput: params.structuredOutputSchema != null,
+      });
 
     chatModel = new ChatOpenAI({
       apiKey,
@@ -334,14 +340,14 @@ export async function fetchLLMCompletion(
       callbacks: finalCallbacks,
       maxRetries,
       configuration: {
-        baseURL: processedBaseURL,
+        baseURL: openAICompatibleProviderConfig?.baseURL,
         timeout: timeoutMs,
         defaultHeaders: extraHeaders,
         ...(proxyDispatcher && {
           fetchOptions: { dispatcher: proxyDispatcher },
         }),
       },
-      modelKwargs: modelParams.providerOptions,
+      modelKwargs: openAICompatibleProviderConfig?.modelKwargs,
       timeout: timeoutMs,
     });
   } else if (modelParams.adapter === LLMAdapter.GoogleAIStudio) {
@@ -378,22 +384,20 @@ export async function fetchLLMCompletion(
     metadata: traceSinkParams?.metadata,
   };
 
-  const thinkingTypes = getThinkingBlockTypes(modelParams.adapter);
+  const thinkingTypes =
+    openAICompatibleProviderConfig?.thinkingBlockTypes ??
+    anthropicCompatibleProviderConfig?.thinkingBlockTypes ??
+    getThinkingBlockTypes(modelParams.adapter);
 
   try {
     // Important: await all generations in the try block as otherwise `processTracedEvents` will run too early in finally block
     if (params.structuredOutputSchema) {
-      // Thinking-capable adapters may produce reasoning blocks that corrupt JSON schema
-      // parsing. Force function calling so the parser reads from tool_calls instead.
-      // Also force function calling for providers (like MiniMax) that return thinking content.
-      // Check both provider name and baseURL since provider may be empty in eval template.
-      const isMiniMaxUrl = baseURL?.includes("minimax") ?? false;
       const structuredOutputConfig =
-        thinkingTypes != null ||
-        hasThinkingContent(modelParams.provider) ||
-        isMiniMaxUrl
+        openAICompatibleProviderConfig?.structuredOutput ??
+        anthropicCompatibleProviderConfig?.structuredOutput ??
+        (thinkingTypes != null
           ? { method: "functionCalling" as const }
-          : undefined;
+          : undefined);
 
       const structuredOutput = await chatModel
         .withStructuredOutput(
@@ -402,16 +406,9 @@ export async function fetchLLMCompletion(
         )
         .invoke(finalMessages, runConfig);
 
-      // For providers with thinking content (like MiniMax), strip thinking tags from the result
-      // as a safety measure even when using function calling mode
-      if (hasThinkingContent(modelParams.provider) || isMiniMaxUrl) {
-        return stripThinkingFromObject(structuredOutput) as Record<
-          string,
-          unknown
-        >;
-      }
-
-      return structuredOutput;
+      return (activeProviderHandler?.normalizeStructuredOutput?.(
+        structuredOutput,
+      ) ?? structuredOutput) as Record<string, unknown>;
     }
 
     if (tools && tools.length > 0) {
@@ -439,7 +436,8 @@ export async function fetchLLMCompletion(
           throw Error("Failed to parse LLM tool call result");
 
         return {
-          ...parsed.data,
+          ...(activeProviderHandler?.normalizeToolCallResponse?.(parsed.data) ??
+            parsed.data),
           ...(reasoning ? { reasoning } : {}),
         };
       }
@@ -447,7 +445,10 @@ export async function fetchLLMCompletion(
       const parsed = ToolCallResponseSchema.safeParse(result);
       if (!parsed.success) throw Error("Failed to parse LLM tool call result");
 
-      return parsed.data;
+      return (
+        activeProviderHandler?.normalizeToolCallResponse?.(parsed.data) ??
+        parsed.data
+      );
     }
 
     if (streaming)
@@ -466,7 +467,9 @@ export async function fetchLLMCompletion(
       .pipe(new StringOutputParser())
       .invoke(finalMessages, runConfig);
 
-    return completion;
+    return (
+      activeProviderHandler?.normalizeTextCompletion?.(completion) ?? completion
+    );
   } catch (e) {
     const responseStatusCode =
       (e as any)?.response?.status ?? (e as any)?.status ?? 500;
@@ -531,7 +534,10 @@ function extractReasoning(
   const parts: string[] = [];
   for (const block of content) {
     if (typeof block !== "string" && thinkingBlockTypes.has(block.type)) {
-      const text = (block as any).text ?? (block as any).reasoning;
+      const text =
+        (block as any).text ??
+        (block as any).reasoning ??
+        (block as any).thinking;
       if (typeof text === "string") parts.push(text);
     }
   }
@@ -558,7 +564,10 @@ function extractCompletionWithReasoning(
     if (typeof block === "string") {
       textParts.push(block);
     } else if (!thinkingBlockTypes.has(block.type)) {
-      const text = (block as any).text ?? (block as any).reasoning;
+      const text =
+        (block as any).text ??
+        (block as any).reasoning ??
+        (block as any).thinking;
       if (typeof text === "string") textParts.push(text);
     }
   }
@@ -567,40 +576,6 @@ function extractCompletionWithReasoning(
     text: textParts.join(""),
     ...(reasoning ? { reasoning } : {}),
   };
-}
-
-/**
- * Process baseURL template for OpenAI adapter only.
- * Replaces {model} placeholder with actual model name.
- * This is a workaround for proxies that require the model name in the URL azureOpenAIBasePath
- * while having OpenAI compliance otherwise
- */
-function processOpenAIBaseURL(params: {
-  url: string | null | undefined;
-  modelName: string;
-}): string | null | undefined {
-  const { url, modelName } = params;
-
-  if (!url) return url;
-
-  // Process MiniMax-style unique URLs that use non-standard completions paths.
-  // MiniMax uses `/v1/text/chatcompletion_v2` which LangChain would incorrectly
-  // append `/chat/completions` to. We strip the completions path so LangChain
-  // can correctly append `/chat/completions` to reach the standard endpoint.
-  const miniMaxCompletionsPaths = ["/v1/text/chatcompletion_v2"];
-
-  for (const path of miniMaxCompletionsPaths) {
-    if (url.endsWith(path)) {
-      return url.slice(0, -path.length);
-    }
-  }
-
-  // Process {model} placeholder
-  if (!url.includes("{model}")) {
-    return url;
-  }
-
-  return url.replace("{model}", modelName);
 }
 
 function extractCleanErrorMessage(rawMessage: string): string {

--- a/packages/shared/src/server/llm/handlers/defaultAnthropic.ts
+++ b/packages/shared/src/server/llm/handlers/defaultAnthropic.ts
@@ -1,0 +1,14 @@
+import {
+  type AnthropicCompatibleProviderHandler,
+  processAnthropicCompatibleBaseURL,
+} from "./shared";
+
+export const defaultAnthropicCompatibleProviderHandler: AnthropicCompatibleProviderHandler =
+  {
+    id: "default-anthropic",
+    matches: () => true,
+    buildConfig: ({ baseURL, providerOptions }) => ({
+      baseURL: processAnthropicCompatibleBaseURL(baseURL),
+      invocationKwargs: providerOptions,
+    }),
+  };

--- a/packages/shared/src/server/llm/handlers/defaultOpenAI.ts
+++ b/packages/shared/src/server/llm/handlers/defaultOpenAI.ts
@@ -1,0 +1,17 @@
+import {
+  type OpenAICompatibleProviderHandler,
+  processOpenAICompatibleBaseURL,
+} from "./shared";
+
+export const defaultOpenAICompatibleProviderHandler: OpenAICompatibleProviderHandler =
+  {
+    id: "default-openai",
+    matches: () => true,
+    buildConfig: ({ baseURL, modelName, providerOptions }) => ({
+      baseURL: processOpenAICompatibleBaseURL({
+        url: baseURL,
+        modelName,
+      }),
+      modelKwargs: providerOptions,
+    }),
+  };

--- a/packages/shared/src/server/llm/handlers/index.ts
+++ b/packages/shared/src/server/llm/handlers/index.ts
@@ -1,0 +1,79 @@
+import { LLMAdapter } from "../types";
+import { defaultAnthropicCompatibleProviderHandler } from "./defaultAnthropic";
+import { defaultOpenAICompatibleProviderHandler } from "./defaultOpenAI";
+import {
+  miniMaxAnthropicCompatibleProviderHandler,
+  miniMaxOpenAICompatibleProviderHandler,
+} from "./minimax";
+import {
+  qwenAnthropicCompatibleProviderHandler,
+  qwenOpenAICompatibleProviderHandler,
+} from "./qwen";
+import type {
+  AnthropicCompatibleProviderHandler,
+  AnthropicCompatibleProviderConfig,
+  OpenAICompatibleProviderConfig,
+  OpenAICompatibleProviderHandler,
+  ProviderHandlerMatchContext,
+  StructuredOutputMethod,
+} from "./shared";
+
+const openAICompatibleProviderHandlers: OpenAICompatibleProviderHandler[] = [
+  qwenOpenAICompatibleProviderHandler,
+  miniMaxOpenAICompatibleProviderHandler,
+  defaultOpenAICompatibleProviderHandler,
+];
+
+const anthropicCompatibleProviderHandlers: AnthropicCompatibleProviderHandler[] =
+  [
+    qwenAnthropicCompatibleProviderHandler,
+    miniMaxAnthropicCompatibleProviderHandler,
+    defaultAnthropicCompatibleProviderHandler,
+  ];
+
+function resolveProviderHandler<
+  T extends { matches: (context: ProviderHandlerMatchContext) => boolean },
+>(handlers: T[], context: ProviderHandlerMatchContext): T {
+  return (
+    handlers.find((handler) => handler.matches(context)) ??
+    handlers[handlers.length - 1]!
+  );
+}
+
+export function resolveOpenAICompatibleProviderHandler(context: {
+  adapter: LLMAdapter;
+  provider?: string;
+  baseURL?: string | null;
+}): OpenAICompatibleProviderHandler | null {
+  if (context.adapter !== LLMAdapter.OpenAI) {
+    return null;
+  }
+
+  return resolveProviderHandler(openAICompatibleProviderHandlers, context);
+}
+
+export function resolveAnthropicCompatibleProviderHandler(context: {
+  adapter: LLMAdapter;
+  provider?: string;
+  baseURL?: string | null;
+}): AnthropicCompatibleProviderHandler | null {
+  if (context.adapter !== LLMAdapter.Anthropic) {
+    return null;
+  }
+
+  return resolveProviderHandler(anthropicCompatibleProviderHandlers, context);
+}
+
+export {
+  processAnthropicCompatibleBaseURL,
+  processOpenAICompatibleBaseURL,
+  stripThinkingFromObject,
+  stripThinkingFromText,
+  THINKING_TAG_REGEX,
+  type AnthropicCompatibleProviderConfig,
+  type AnthropicCompatibleProviderHandler,
+  type OpenAICompatibleProviderConfig,
+  type OpenAICompatibleProviderHandler,
+  type ProviderHandlerMatchContext,
+  type StructuredOutputMethod,
+} from "./shared";

--- a/packages/shared/src/server/llm/handlers/minimax.ts
+++ b/packages/shared/src/server/llm/handlers/minimax.ts
@@ -1,0 +1,101 @@
+import {
+  type AnthropicCompatibleProviderHandler,
+  type OpenAICompatibleProviderHandler,
+  getHostname,
+  isAnthropicThinkingEnabled,
+  isMiniMaxM3Model,
+  mergeProviderOptions,
+  normalizeProviderName,
+  normalizeToolCallResponseContent,
+  processAnthropicCompatibleBaseURL,
+  processOpenAICompatibleBaseURL,
+  stripThinkingFromObject,
+  stripThinkingFromText,
+} from "./shared";
+
+function matchesMiniMaxProvider(params: {
+  provider?: string;
+  baseURL?: string | null;
+}): boolean {
+  const normalizedProvider = normalizeProviderName(params.provider);
+  const hostname = getHostname(params.baseURL);
+
+  return normalizedProvider === "minimax" || hostname === "api.minimaxi.com";
+}
+
+function hasExplicitThinkingConfig(
+  providerOptions?: Record<string, unknown>,
+): boolean {
+  return providerOptions != null && "thinking" in providerOptions;
+}
+
+export const miniMaxOpenAICompatibleProviderHandler: OpenAICompatibleProviderHandler =
+  {
+    id: "minimax-openai",
+    matches: matchesMiniMaxProvider,
+    buildConfig: ({
+      baseURL,
+      modelName,
+      providerOptions,
+      hasStructuredOutput,
+    }) => ({
+      baseURL: processOpenAICompatibleBaseURL({
+        url: baseURL,
+        modelName,
+      }),
+      modelKwargs: mergeProviderOptions(
+        {
+          reasoning_split: true,
+        },
+        providerOptions,
+      ),
+      // MiniMax often returns markdown-wrapped content for jsonSchema mode;
+      // function calling yields stable machine-parsable output for evals.
+      structuredOutput: hasStructuredOutput
+        ? { method: "functionCalling" }
+        : undefined,
+    }),
+    normalizeTextCompletion: stripThinkingFromText,
+    normalizeStructuredOutput: stripThinkingFromObject,
+    normalizeToolCallResponse: (response) =>
+      normalizeToolCallResponseContent(response, stripThinkingFromText),
+  };
+
+export const miniMaxAnthropicCompatibleProviderHandler: AnthropicCompatibleProviderHandler =
+  {
+    id: "minimax-anthropic",
+    matches: matchesMiniMaxProvider,
+    buildConfig: ({
+      baseURL,
+      modelName,
+      providerOptions,
+      hasStructuredOutput,
+    }) => {
+      const invocationKwargs = hasStructuredOutput
+        ? {
+            ...(providerOptions ?? {}),
+            thinking: { type: "disabled" },
+          }
+        : mergeProviderOptions(
+            isMiniMaxM3Model(modelName)
+              ? { thinking: { type: "disabled" } }
+              : {},
+            providerOptions,
+          );
+
+      const thinkingEnabled = hasStructuredOutput
+        ? false
+        : hasExplicitThinkingConfig(invocationKwargs)
+          ? isAnthropicThinkingEnabled(invocationKwargs)
+          : !isMiniMaxM3Model(modelName);
+
+      return {
+        baseURL: processAnthropicCompatibleBaseURL(baseURL),
+        invocationKwargs,
+        structuredOutput: hasStructuredOutput
+          ? { method: "functionCalling" }
+          : undefined,
+        thinkingBlockTypes: thinkingEnabled ? new Set(["thinking"]) : undefined,
+      };
+    },
+  };

--- a/packages/shared/src/server/llm/handlers/qwen.ts
+++ b/packages/shared/src/server/llm/handlers/qwen.ts
@@ -1,0 +1,75 @@
+import {
+  type AnthropicCompatibleProviderHandler,
+  type OpenAICompatibleProviderHandler,
+  getHostname,
+  isAnthropicThinkingEnabled,
+  isDashScopeHost,
+  mergeProviderOptions,
+  normalizeProviderName,
+  processAnthropicCompatibleBaseURL,
+  processOpenAICompatibleBaseURL,
+} from "./shared";
+
+function matchesQwenProvider(params: {
+  provider?: string;
+  baseURL?: string | null;
+}): boolean {
+  const normalizedProvider = normalizeProviderName(params.provider);
+  const hostname = getHostname(params.baseURL);
+
+  return normalizedProvider === "qwen" || isDashScopeHost(hostname);
+}
+
+export const qwenOpenAICompatibleProviderHandler: OpenAICompatibleProviderHandler =
+  {
+    id: "qwen-openai",
+    matches: matchesQwenProvider,
+    buildConfig: ({
+      baseURL,
+      modelName,
+      providerOptions,
+      hasStructuredOutput,
+    }) => {
+      const modelKwargs = mergeProviderOptions(
+        {
+          enable_thinking: false,
+        },
+        providerOptions,
+      );
+
+      return {
+        baseURL: processOpenAICompatibleBaseURL({
+          url: baseURL,
+          modelName,
+        }),
+        modelKwargs,
+        // DashScope's OpenAI-compatible endpoint rejects json_object/json_schema
+        // structured output unless the prompt contains explicit "json" wording.
+        structuredOutput: hasStructuredOutput
+          ? { method: "functionCalling" }
+          : undefined,
+      };
+    },
+  };
+
+export const qwenAnthropicCompatibleProviderHandler: AnthropicCompatibleProviderHandler =
+  {
+    id: "qwen-anthropic",
+    matches: matchesQwenProvider,
+    buildConfig: ({ baseURL, providerOptions }) => {
+      const invocationKwargs = mergeProviderOptions(
+        {
+          thinking: { type: "disabled" },
+        },
+        providerOptions,
+      );
+
+      return {
+        baseURL: processAnthropicCompatibleBaseURL(baseURL),
+        invocationKwargs,
+        thinkingBlockTypes: isAnthropicThinkingEnabled(invocationKwargs)
+          ? new Set(["thinking"])
+          : undefined,
+      };
+    },
+  };

--- a/packages/shared/src/server/llm/handlers/shared.ts
+++ b/packages/shared/src/server/llm/handlers/shared.ts
@@ -1,0 +1,182 @@
+import type { ToolCallResponse } from "../types";
+
+export type StructuredOutputMethod = "functionCalling" | "jsonSchema";
+
+export type ProviderHandlerMatchContext = {
+  provider?: string;
+  baseURL?: string | null;
+};
+
+export type OpenAICompatibleProviderBuildContext =
+  ProviderHandlerMatchContext & {
+    modelName: string;
+    providerOptions?: Record<string, unknown>;
+    hasStructuredOutput: boolean;
+  };
+
+export type AnthropicCompatibleProviderBuildContext =
+  ProviderHandlerMatchContext & {
+    modelName: string;
+    providerOptions?: Record<string, unknown>;
+    hasStructuredOutput: boolean;
+  };
+
+type BaseProviderConfig = {
+  baseURL?: string | null;
+  structuredOutput?: {
+    method: StructuredOutputMethod;
+  };
+  thinkingBlockTypes?: Set<string>;
+};
+
+export type OpenAICompatibleProviderConfig = BaseProviderConfig & {
+  modelKwargs?: Record<string, unknown>;
+};
+
+export type AnthropicCompatibleProviderConfig = BaseProviderConfig & {
+  invocationKwargs?: Record<string, unknown>;
+};
+
+type BaseProviderHandler = {
+  id: string;
+  matches: (context: ProviderHandlerMatchContext) => boolean;
+  normalizeTextCompletion?: (completion: string) => string;
+  normalizeStructuredOutput?: (output: unknown) => unknown;
+  normalizeToolCallResponse?: (response: ToolCallResponse) => ToolCallResponse;
+};
+
+export type OpenAICompatibleProviderHandler = BaseProviderHandler & {
+  buildConfig: (
+    context: OpenAICompatibleProviderBuildContext,
+  ) => OpenAICompatibleProviderConfig;
+};
+
+export type AnthropicCompatibleProviderHandler = BaseProviderHandler & {
+  buildConfig: (
+    context: AnthropicCompatibleProviderBuildContext,
+  ) => AnthropicCompatibleProviderConfig;
+};
+
+export const THINKING_TAG_REGEX = /<think>[\s\S]*?<\/think>/gi;
+
+export function normalizeProviderName(provider: string | undefined): string {
+  return provider?.trim().toLowerCase() ?? "";
+}
+
+export function getHostname(
+  baseURL: string | null | undefined,
+): string | undefined {
+  if (!baseURL) return undefined;
+
+  try {
+    return new URL(baseURL).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+export function mergeProviderOptions(
+  defaults: Record<string, unknown>,
+  providerOptions?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...defaults,
+    ...(providerOptions ?? {}),
+  };
+}
+
+export function stripThinkingFromText(text: string): string {
+  return text.replace(THINKING_TAG_REGEX, "").trim();
+}
+
+export function stripThinkingFromObject(obj: unknown): unknown {
+  if (typeof obj === "string") {
+    return obj.replace(THINKING_TAG_REGEX, "");
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(stripThinkingFromObject);
+  }
+  if (obj !== null && typeof obj === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = stripThinkingFromObject(value);
+    }
+    return result;
+  }
+  return obj;
+}
+
+export function normalizeToolCallResponseContent(
+  response: ToolCallResponse,
+  normalizeText: (text: string) => string,
+): ToolCallResponse {
+  return {
+    ...response,
+    content:
+      typeof response.content === "string"
+        ? normalizeText(response.content)
+        : response.content,
+  };
+}
+
+export function processOpenAICompatibleBaseURL(params: {
+  url: string | null | undefined;
+  modelName: string;
+}): string | null | undefined {
+  const { url, modelName } = params;
+
+  if (!url) return url;
+
+  if (url.includes("{model}")) {
+    return url.replace("{model}", modelName);
+  }
+
+  const miniMaxCompletionsPaths = ["/v1/text/chatcompletion_v2"];
+
+  for (const path of miniMaxCompletionsPaths) {
+    if (url.endsWith(path)) {
+      return url.slice(0, -path.length);
+    }
+  }
+
+  return url;
+}
+
+export function processAnthropicCompatibleBaseURL(
+  url: string | null | undefined,
+): string | null | undefined {
+  if (!url) return url;
+
+  const normalizedMessagesPath = ["/v1/messages", "/messages"];
+
+  for (const path of normalizedMessagesPath) {
+    if (url.endsWith(path)) {
+      return url.slice(0, -path.length);
+    }
+  }
+
+  return url;
+}
+
+export function isAnthropicThinkingEnabled(
+  invocationKwargs?: Record<string, unknown>,
+): boolean {
+  const thinking = invocationKwargs?.thinking;
+
+  if (!thinking || typeof thinking !== "object") {
+    return false;
+  }
+
+  return (thinking as { type?: string }).type !== "disabled";
+}
+
+export function isDashScopeHost(hostname: string | undefined): boolean {
+  return (
+    hostname === "dashscope.aliyuncs.com" ||
+    hostname === "dashscope-intl.aliyuncs.com"
+  );
+}
+
+export function isMiniMaxM3Model(modelName: string): boolean {
+  return modelName.startsWith("MiniMax-M3");
+}


### PR DESCRIPTION
Extract provider-specific OpenAI- and Anthropic-compatible behavior out of fetchLLMCompletion into dedicated handlers.

Add first-class Qwen and MiniMax handlers to normalize compatible base URLs,
apply provider-specific defaults, and stabilize structured output flows.

This fixes provider issues such as:
- Qwen structured output failing on json_object/json_schema mode
- MiniMax returning thinking-wrapped output that breaks parsing
- MiniMax Anthropic-compatible structured output on MiniMax-M2.7 requiring thinking to be disabled

Also add unit coverage for handler resolution, base URL normalization,
thinking overrides, structured output config, and response cleanup.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Summary

- Impacted package: `@langfuse/shared`
- Extract provider-specific LLM compatibility logic from `fetchLLMCompletion` into dedicated handlers
- Add first-class support for Qwen and MiniMax across both OpenAI-compatible and Anthropic-compatible integrations
- Fix structured output and reasoning-related issues that were causing evaluator/default-model validation failures and brittle parsing

## Problem

Qwen and MiniMax expose OpenAI-compatible and/or Anthropic-compatible APIs, but their behavior does not fully match the assumptions in the current generic Litefuse integration.

Before this change:

- provider-specific behavior was partially hard-coded inside `fetchLLMCompletion`
- MiniMax support was implemented as inline special cases, which made the code harder to maintain and extend
- Qwen structured output could fail when using JSON-schema style output because DashScope rejects those modes unless the prompt explicitly references JSON
- MiniMax responses could include thinking content that polluted text and structured outputs
- MiniMax Anthropic-compatible structured output on `MiniMax-M2.7` was not stable unless thinking was explicitly disabled
- compatible base URL normalization was not consistently handled for provider-specific endpoint shapes

## Changes

- Add a provider handler layer under `packages/shared/src/server/llm/handlers`
- Introduce default OpenAI-compatible and Anthropic-compatible handlers for generic behavior
- Add dedicated Qwen handlers
- Add dedicated MiniMax handlers
- Refactor `fetchLLMCompletion` to resolve and apply provider-specific handler config instead of keeping provider logic inline
- Export handler utilities from the shared server entrypoint
- Add unit coverage for handler resolution and provider-specific behavior

## Provider-specific behavior added

### Qwen

- Match Qwen either by provider name or DashScope host
- Disable thinking by default for OpenAI-compatible requests
- Disable thinking by default for Anthropic-compatible requests unless explicitly overridden
- Force `functionCalling` for structured output to avoid DashScope JSON mode incompatibilities
- Normalize Anthropic-compatible `/v1/messages` style base URLs before passing them to LangChain

### MiniMax

- Match MiniMax either by provider name or MiniMax host
- Keep `reasoning_split: true` as the default for OpenAI-compatible requests
- Force `functionCalling` for structured output because MiniMax can return non-JSON-safe reasoning content
- Strip `<think>...</think>` content from plain text completions, tool-call content, and structured output payloads
- Normalize Anthropic-compatible `/v1/messages` style base URLs before passing them to LangChain
- Disable thinking for Anthropic-compatible structured output on `MiniMax-M2.7`
- Continue to disable thinking by default for `MiniMax-M3`
- Preserve explicit provider option overrides where supported

## Testing

- `pnpm --filter @langfuse/shared exec vitest run src/server/llm/__tests__/providerHandlers.unit.test.ts`
- `pnpm --filter @langfuse/shared run typecheck`
- `pnpm run build:check`

## Notes

This PR is intended to improve correctness and maintainability at the same time:

- correctness by encoding Qwen and MiniMax protocol quirks explicitly
- maintainability by replacing inline special cases with modular provider handlers that can be extended per provider

<!-- Please provide a loom video for visual changes to speed up reviews
Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/selectdb/langfuse-doris/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

