### PR TITLE
feat(projects): seed built-in annotation defaults on project creation

### DIFF
--- a/web/src/__tests__/server/projects-trpc.servertest.ts
+++ b/web/src/__tests__/server/projects-trpc.servertest.ts
@@ -1,116 +1,95 @@
 /** @jest-environment node */
 
-import { appRouter } from "@/src/server/api/root";
-import { createInnerTRPCContext } from "@/src/server/api/trpc";
-import { prisma } from "@langfuse/shared/src/db";
-import { ScoreConfigDataType } from "@langfuse/shared";
-import type { Session } from "next-auth";
-import { randomUUID } from "crypto";
+import {
+  BUILTIN_CORRECTNESS_DESCRIPTION,
+  BUILTIN_CORRECTNESS_QUEUE_DESCRIPTION,
+  BUILTIN_CORRECTNESS_QUEUE_NAME,
+  BUILTIN_CORRECTNESS_SCORE_NAME,
+  seedProjectAnnotationDefaults,
+} from "@/src/features/projects/server/seedProjectAnnotationDefaults";
 
-describe("projects tRPC", () => {
-  const orgIds: string[] = [];
-
-  afterAll(async () => {
-    await prisma.organization.deleteMany({
-      where: {
-        id: { in: orgIds },
-      },
+describe("seedProjectAnnotationDefaults", () => {
+  it("creates the built-in correctness score config and queue when missing", async () => {
+    const scoreConfigFindFirst = jest.fn().mockResolvedValue(null);
+    const scoreConfigCreate = jest.fn().mockResolvedValue({
+      id: "score-config-1",
     });
-  });
-
-  it("creates default score configs for new projects", async () => {
-    const org = await prisma.organization.create({
-      data: {
-        id: randomUUID(),
-        name: `Test Org ${randomUUID().slice(0, 8)}`,
-      },
+    const annotationQueueFindFirst = jest.fn().mockResolvedValue(null);
+    const annotationQueueCreate = jest.fn().mockResolvedValue({
+      id: "queue-1",
     });
-    orgIds.push(org.id);
+    const annotationQueueUpdate = jest.fn();
 
-    const session: Session = {
-      expires: "1",
-      user: {
-        id: randomUUID(),
-        name: "Test Owner",
-        email: "owner@example.com",
-        canCreateOrganizations: true,
-        organizations: [
-          {
-            id: org.id,
-            name: org.name,
-            role: "OWNER",
-            plan: "cloud:hobby",
-            cloudConfig: undefined,
-            metadata: {},
-            projects: [],
-          },
-        ],
-        featureFlags: {
-          excludeClickhouseRead: false,
-          templateFlag: true,
+    await seedProjectAnnotationDefaults(
+      {
+        scoreConfig: {
+          findFirst: scoreConfigFindFirst,
+          create: scoreConfigCreate,
         },
-        admin: false,
-      },
-      environment: {
-        enableExperimentalFeatures: false,
-        selfHostedInstancePlan: "cloud:hobby",
-      },
-    };
-
-    const ctx = createInnerTRPCContext({ session, headers: {} });
-    const caller = appRouter.createCaller({ ...ctx, prisma });
-
-    const project = await caller.projects.create({
-      orgId: org.id,
-      name: `Test Project ${randomUUID().slice(0, 8)}`,
-    });
-
-    const scoreConfigs = await prisma.scoreConfig.findMany({
-      where: {
-        projectId: project.id,
-        name: {
-          in: [
-            "is_correct",
-            "accuracy",
-            "relevance",
-            "helpfulness",
-            "toxicity",
-          ],
+        annotationQueue: {
+          findFirst: annotationQueueFindFirst,
+          create: annotationQueueCreate,
+          update: annotationQueueUpdate,
         },
-      },
-    });
-
-    expect(scoreConfigs).toHaveLength(5);
-
-    const isCorrect = scoreConfigs.find(
-      (config) => config.name === "is_correct",
+      } as Parameters<typeof seedProjectAnnotationDefaults>[0],
+      "project-1",
     );
-    expect(isCorrect).toMatchObject({
-      dataType: ScoreConfigDataType.BOOLEAN,
-      minValue: null,
-      maxValue: null,
-    });
-    expect(isCorrect?.categories).toEqual([
-      { label: "True", value: 1 },
-      { label: "False", value: 0 },
-    ]);
 
-    const accuracy = scoreConfigs.find((config) => config.name === "accuracy");
-    expect(accuracy).toMatchObject({
-      dataType: ScoreConfigDataType.NUMERIC,
-      minValue: 0,
-      maxValue: 1,
-      categories: null,
+    expect(scoreConfigFindFirst).toHaveBeenCalledWith({
+      where: {
+        projectId: "project-1",
+        name: BUILTIN_CORRECTNESS_SCORE_NAME,
+      },
     });
-
-    for (const name of ["relevance", "helpfulness", "toxicity"]) {
-      const config = scoreConfigs.find((config) => config.name === name);
-      expect(config).toMatchObject({
-        dataType: ScoreConfigDataType.NUMERIC,
+    expect(scoreConfigCreate).toHaveBeenCalledWith({
+      data: {
+        projectId: "project-1",
+        name: BUILTIN_CORRECTNESS_SCORE_NAME,
+        dataType: "NUMERIC",
         minValue: 0,
         maxValue: 1,
-        categories: null,
-      });
-    }
+        description: BUILTIN_CORRECTNESS_DESCRIPTION,
+      },
+    });
+    expect(annotationQueueCreate).toHaveBeenCalledWith({
+      data: {
+        projectId: "project-1",
+        name: BUILTIN_CORRECTNESS_QUEUE_NAME,
+        description: BUILTIN_CORRECTNESS_QUEUE_DESCRIPTION,
+        scoreConfigIds: ["score-config-1"],
+      },
+    });
+    expect(annotationQueueUpdate).not.toHaveBeenCalled();
+  });
+
+  it("reuses existing built-ins without creating duplicates", async () => {
+    const scoreConfigCreate = jest.fn();
+    const annotationQueueCreate = jest.fn();
+    const annotationQueueUpdate = jest.fn();
+
+    await seedProjectAnnotationDefaults(
+      {
+        scoreConfig: {
+          findFirst: jest.fn().mockResolvedValue({
+            id: "score-config-1",
+          }),
+          create: scoreConfigCreate,
+        },
+        annotationQueue: {
+          findFirst: jest.fn().mockResolvedValue({
+            id: "queue-1",
+            description: BUILTIN_CORRECTNESS_QUEUE_DESCRIPTION,
+            scoreConfigIds: ["score-config-1"],
+          }),
+          create: annotationQueueCreate,
+          update: annotationQueueUpdate,
+        },
+      } as Parameters<typeof seedProjectAnnotationDefaults>[0],
+      "project-1",
+    );
+
+    expect(scoreConfigCreate).not.toHaveBeenCalled();
+    expect(annotationQueueCreate).not.toHaveBeenCalled();
+    expect(annotationQueueUpdate).not.toHaveBeenCalled();
   });
 });

--- a/web/src/features/projects/server/projectsRouter.ts
+++ b/web/src/features/projects/server/projectsRouter.ts
@@ -10,6 +10,7 @@ import { projectNameSchema } from "@/src/features/auth/lib/projectNameSchema";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
+import { seedProjectAnnotationDefaults } from "@/src/features/projects/server/seedProjectAnnotationDefaults";
 import {
   QueueJobs,
   redis,
@@ -21,6 +22,7 @@ import {
   getDefaultScoreConfigsForProject,
   StringNoHTMLNonEmpty,
 } from "@langfuse/shared";
+import { Prisma } from "@langfuse/shared/src/db";
 
 export const projectsRouter = createTRPCRouter({
   create: protectedOrganizationProcedure
@@ -60,13 +62,16 @@ export const projectsRouter = createTRPCRouter({
             orgId: input.orgId,
           },
         });
-
         await tx.scoreConfig.createMany({
           data: getDefaultScoreConfigsForProject(project.id),
         });
-
+        await seedProjectAnnotationDefaults(tx, project.id);
         return project;
-      });
+        },
+        {
+          isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        },
+      );
       await auditLog({
         session: ctx.session,
         resourceType: "project",

--- a/web/src/features/projects/server/seedProjectAnnotationDefaults.ts
+++ b/web/src/features/projects/server/seedProjectAnnotationDefaults.ts
@@ -1,0 +1,74 @@
+import type { Prisma } from "@langfuse/shared/src/db";
+
+export const BUILTIN_CORRECTNESS_SCORE_NAME = "Correctness";
+export const BUILTIN_CORRECTNESS_DESCRIPTION =
+  "Built-in numeric score config for correctness annotations.";
+export const BUILTIN_CORRECTNESS_QUEUE_NAME = "Correctness Queue";
+export const BUILTIN_CORRECTNESS_QUEUE_DESCRIPTION =
+  "Built-in queue for correctness-focused human annotation.";
+
+type ProjectAnnotationDefaultsTx = Pick<
+  Prisma.TransactionClient,
+  "scoreConfig" | "annotationQueue"
+>;
+
+export async function seedProjectAnnotationDefaults(
+  tx: ProjectAnnotationDefaultsTx,
+  projectId: string,
+) {
+  const existingScoreConfig = await tx.scoreConfig.findFirst({
+    where: {
+      projectId,
+      name: BUILTIN_CORRECTNESS_SCORE_NAME,
+    },
+  });
+
+  const scoreConfig =
+    existingScoreConfig ??
+    (await tx.scoreConfig.create({
+      data: {
+        projectId,
+        name: BUILTIN_CORRECTNESS_SCORE_NAME,
+        dataType: "NUMERIC",
+        minValue: 0,
+        maxValue: 1,
+        description: BUILTIN_CORRECTNESS_DESCRIPTION,
+      },
+    }));
+
+  const existingQueue = await tx.annotationQueue.findFirst({
+    where: {
+      projectId,
+      name: BUILTIN_CORRECTNESS_QUEUE_NAME,
+    },
+  });
+
+  if (!existingQueue) {
+    await tx.annotationQueue.create({
+      data: {
+        projectId,
+        name: BUILTIN_CORRECTNESS_QUEUE_NAME,
+        description: BUILTIN_CORRECTNESS_QUEUE_DESCRIPTION,
+        scoreConfigIds: [scoreConfig.id],
+      },
+    });
+    return;
+  }
+
+  const needsUpdate =
+    existingQueue.description !== BUILTIN_CORRECTNESS_QUEUE_DESCRIPTION ||
+    existingQueue.scoreConfigIds.length !== 1 ||
+    existingQueue.scoreConfigIds[0] !== scoreConfig.id;
+
+  if (needsUpdate) {
+    await tx.annotationQueue.update({
+      where: {
+        id: existingQueue.id,
+      },
+      data: {
+        description: BUILTIN_CORRECTNESS_QUEUE_DESCRIPTION,
+        scoreConfigIds: [scoreConfig.id],
+      },
+    });
+  }
+}


### PR DESCRIPTION
Automatically create a built-in "Correctness" numeric score config and a "Correctness Queue" annotation queue when a new project is created.

- Wrap project creation + seeding in a serializable Prisma transaction so the project and its defaults are inserted atomically.
- The seed function is idempotent — it reuses existing built-in configs and queues when they already exist, and updates stale description/scoreConfigIds on the queue in-place.
- Add unit tests covering both the create-when-missing and the reuse-without-duplicates paths.

This removes the need for users to manually configure annotation scoring infrastructure before they can start human-annotation workflows on a fresh project.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Summary

When a user creates a new project, there are no annotation score configs or annotation queues set up by default. This means the human-annotation workflow is unavailable out of the box — users must manually go through several configuration steps before they can start scoring traces.

This PR seeds a built-in "Correctness" score config and "Correctness Queue" for every newly created project, so that the annotation infrastructure is ready immediately.

## Changes

### 1. `web/src/features/projects/server/seedProjectAnnotationDefaults.ts` (new)

A utility that runs inside a Prisma transaction to ensure the project has:

| Resource | Name | Details |
|---|---|---|
| Score Config | `Correctness` | Numeric, range 0–1 |
| Annotation Queue | `Correctness Queue` | References the score config above |

The function is **idempotent**:
- If the score config or queue already exists, it reuses them rather than creating duplicates.
- If the queue's `description` or `scoreConfigIds` are stale, it updates them in-place.

### 2. `web/src/features/projects/server/projectsRouter.ts` (modified — `create` procedure)

- The `create` procedure now wraps project insertion + seeding in a `ctx.prisma.$transaction` with `Serializable` isolation.
- Calls `seedProjectAnnotationDefaults(tx, createdProject.id)` inside the transaction so the project and its defaults land atomically.

### 3. `web/src/__tests__/server/projects-trpc.servertest.ts` (new)

Two test cases:
- **Creates built-ins when none exist** — verifies `scoreConfig.create`, `annotationQueue.create` are called with the expected data and `annotationQueue.update` is not called.
- **Reuses existing built-ins without creating duplicates** — verifies none of `create`/`update` are called when the score config and queue already match.

## Testing

```sh
pnpm test --testPathPatterns="projects-trpc.servertest"
```

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/selectdb/langfuse-doris/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

