### PR TITLE
fix(evals): stop preselecting Object Field on template variable mappings

### DIFF
--- a/web/src/__tests__/server/eval-variable-mapping-validation.servertest.ts
+++ b/web/src/__tests__/server/eval-variable-mapping-validation.servertest.ts
@@ -1,0 +1,49 @@
+/** @jest-environment node */
+
+import { EvalTargetObject } from "@langfuse/shared";
+import {
+  createDefaultFormMappings,
+  inferDefaultMapping,
+} from "@/src/features/evals/utils/evaluator-form-utils";
+import { validateAndTransformVariableMapping } from "@/src/features/evals/utils/variable-mapping-validation";
+
+describe("evaluator variable mapping defaults", () => {
+  it("does not preselect an Object Field for new template variables", () => {
+    expect(inferDefaultMapping("query")).toEqual({
+      selectedColumnId: undefined,
+    });
+    expect(inferDefaultMapping("generation")).toEqual({
+      selectedColumnId: undefined,
+    });
+    expect(
+      createDefaultFormMappings(["query"], EvalTargetObject.TRACE),
+    ).toEqual([
+      {
+        templateVariable: "query",
+        langfuseObject: "trace",
+        objectName: null,
+        selectedColumnId: undefined,
+        jsonSelector: null,
+      },
+    ]);
+  });
+
+  it("returns an explicit error when any Object Field is empty", () => {
+    expect(
+      validateAndTransformVariableMapping(
+        [
+          {
+            templateVariable: "query",
+            langfuseObject: "trace",
+            selectedColumnId: "",
+          },
+        ],
+        EvalTargetObject.TRACE,
+      ),
+    ).toEqual({
+      success: false,
+      error:
+        "Please select an Object Field for every Evaluation Prompt variable before executing the evaluator.",
+    });
+  });
+});

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -44,10 +44,10 @@ import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePos
 import { Checkbox } from "@/src/components/ui/checkbox";
 import { Switch } from "@/src/components/ui/switch";
 import {
+  createDefaultFormMappings,
   evalConfigFormSchema,
   type EvalFormType,
   getTargetDisplayName,
-  inferDefaultMapping,
   type LangfuseObject,
 } from "@/src/features/evals/utils/evaluator-form-utils";
 import { validateAndTransformVariableMapping } from "@/src/features/evals/utils/variable-mapping-validation";
@@ -328,16 +328,9 @@ export const InnerEvaluatorForm = (props: {
           : z
               .array(variableMapping)
               .parse(props.existingEvaluator.variableMapping)
-        : z.array(variableMapping).parse(
-            props.evalTemplate
-              ? props.evalTemplate.vars.map((v) => ({
-                  templateVariable: v,
-                  langfuseObject: "trace" as const,
-                  objectName: null,
-                  selectedColumnId: "input",
-                  jsonSelector: null,
-                }))
-              : [],
+        : createDefaultFormMappings(
+            props.evalTemplate?.vars ?? [],
+            props.existingEvaluator?.targetObject ?? EvalTargetObject.EVENT,
           ),
       sampling: props.existingEvaluator?.sampling
         ? props.existingEvaluator.sampling.toNumber()
@@ -360,13 +353,7 @@ export const InnerEvaluatorForm = (props: {
       const target = form.getValues("target");
       form.setValue(
         "mapping",
-        props.evalTemplate.vars.map((v) => ({
-          templateVariable: v,
-          langfuseObject: isLegacyEvalTarget(target)
-            ? ("trace" as const)
-            : undefined,
-          ...inferDefaultMapping(v),
-        })),
+        createDefaultFormMappings(props.evalTemplate.vars, target),
       );
       form.setValue("scoreName", `${props.evalTemplate.name}`);
     }

--- a/web/src/features/evals/components/variable-mapping-card.tsx
+++ b/web/src/features/evals/components/variable-mapping-card.tsx
@@ -438,7 +438,7 @@ export const VariableMappingCard = ({
                                       }}
                                     >
                                       <SelectTrigger>
-                                        <SelectValue placeholder="Object type" />
+                                        <SelectValue placeholder="Select field" />
                                       </SelectTrigger>
                                       <SelectContent>
                                         {availableVariables

--- a/web/src/features/evals/utils/evaluator-form-utils.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.ts
@@ -3,9 +3,8 @@ import {
   singleFilter,
   type langfuseObjects,
   TimeScopeSchema,
+  wipVariableMapping,
 } from "@langfuse/shared";
-import { wipVariableMapping } from "@langfuse/shared";
-import { OUTPUT_MAPPING } from "@/src/features/evals/utils/evaluator-constants";
 
 // Legacy eval targets (TRACE, DATASET) use full variable mapping UI with object selector
 // Modern eval targets (EVENT, EXPERIMENT) use simplified UI with just column selection
@@ -30,14 +29,24 @@ export type LangfuseObject = (typeof langfuseObjects)[number];
 export type VariableMapping = z.infer<typeof wipVariableMapping>;
 
 export const inferDefaultMapping = (
-  variable: string,
+  _variable: string,
 ): Pick<VariableMapping, "selectedColumnId"> => {
   return {
-    selectedColumnId: OUTPUT_MAPPING.includes(variable.toLowerCase())
-      ? "output"
-      : "input",
+    selectedColumnId: undefined,
   };
 };
+
+export const createDefaultFormMappings = (
+  variables: string[],
+  target: string,
+): z.infer<typeof wipVariableMapping>[] =>
+  variables.map((templateVariable) => ({
+    templateVariable,
+    langfuseObject: isLegacyEvalTarget(target) ? "trace" : undefined,
+    objectName: isLegacyEvalTarget(target) ? null : undefined,
+    jsonSelector: null,
+    ...inferDefaultMapping(templateVariable),
+  }));
 
 export const fieldHasJsonSelectorOption = (
   selectedColumnId: string | undefined | null,

--- a/web/src/features/evals/utils/variable-mapping-validation.ts
+++ b/web/src/features/evals/utils/variable-mapping-validation.ts
@@ -29,6 +29,9 @@ type ValidationResult =
       error: string;
     };
 
+const OBJECT_FIELD_REQUIRED_ERROR =
+  "Please select an Object Field for every Evaluation Prompt variable before executing the evaluator.";
+
 /**
  * Validates and transforms variable mappings based on the target type.
  * Returns validated data or an error message.
@@ -51,7 +54,7 @@ export function validateAndTransformVariableMapping(
   if (incompleteMappings.length > 0) {
     return {
       success: false,
-      error: "Please complete all variable mappings",
+      error: OBJECT_FIELD_REQUIRED_ERROR,
     };
   }
 
@@ -109,7 +112,7 @@ export function validateAndTransformVariableMapping(
   if (!validatedVarMapping.success) {
     return {
       success: false,
-      error: "Please complete all variable mappings",
+      error: OBJECT_FIELD_REQUIRED_ERROR,
     };
   }
 


### PR DESCRIPTION
When creating an evaluator from a template, the variable mapping form previously auto-selected "input" or "output" as the Object Field based on the variable name. This was error-prone — an incorrect preselection could slip through and silently route the wrong trace/observation data into the evaluation prompt.

Now all template variables default to an unset Object Field, forcing the user to make an explicit selection. The validation error message is also improved from the generic "Please complete all variable mappings" to the specific "Please select an Object Field for every Evaluation Prompt variable before executing the evaluator."

- Remove OUTPUT_MAPPING heuristic from inferDefaultMapping; always return selectedColumnId: undefined.
- Add createDefaultFormMappings() to centralize mapping construction across the new-evaluator and template-switch code paths.
- Update the select placeholder from "Object type" to "Select field".

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Problem

When a user creates an evaluator from a template, the variable mapping form auto-selects an Object Field (`input` vs `output`) based on a hardcoded heuristic in `inferDefaultMapping`. If the variable name happens to match the `OUTPUT_MAPPING` list (e.g. `query`), it gets `selectedColumnId: "input"` — otherwise `"output"`.

This preselection is invisible in the form (the select dropdown already shows a value) and can easily be missed. If the wrong field is auto-selected, the evaluator silently feeds incorrect data into the prompt at execution time. There is no guardrail to catch this.

## Changes

### 1. `evaluator-form-utils.ts`

- **`inferDefaultMapping`** no longer applies the `OUTPUT_MAPPING` heuristic — it always returns `selectedColumnId: undefined`, leaving the field unset for the user to pick explicitly.
- **New `createDefaultFormMappings`** function centralizes the variable-mapping construction that was previously duplicated across `inner-evaluator-form.tsx`. It accepts the template variables array and the eval target object, and returns a correctly-shaped mapping array.
- Removed the now-unused `OUTPUT_MAPPING` import.

### 2. `inner-evaluator-form.tsx`

- Both the `defaultValues` block and the template-switch `useEffect` now delegate to `createDefaultFormMappings` instead of constructing mappings inline.
- This eliminates the duplicated mapping logic and ensures the "no preselection" behavior is consistent across the new-evaluator and template-change paths.

### 3. `variable-mapping-validation.ts`

- Exported `OBJECT_FIELD_REQUIRED_ERROR` as a named constant.
- Changed the validation error from the generic `"Please complete all variable mappings"` to:
  > Please select an Object Field for every Evaluation Prompt variable before executing the evaluator.
- This message now appears in both validation branches (`incompleteMappings` and the final Zod parse failure), giving users a clear, actionable prompt.

### 4. `variable-mapping-card.tsx`

- Updated the select dropdown placeholder from `"Object type"` to `"Select field"` to better match the surrounding UI language.

### 5. `eval-variable-mapping-validation.servertest.ts` (new)

Two test cases:
- **No preselection** — verifies that `inferDefaultMapping` returns `selectedColumnId: undefined` for both `"query"` and `"generation"` variables, and that `createDefaultFormMappings` produces mappings without a preselected field.
- **Explicit error on empty field** — verifies that `validateAndTransformVariableMapping` returns the new specific error when `selectedColumnId` is empty.

## Testing

```sh
pnpm test --testPathPatterns="eval-variable-mapping-validation"
```

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/selectdb/langfuse-doris/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

