### PR TITLE
feat(blob-storage): add export source, field groups, and compression …

### DIFF
--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -54,6 +54,24 @@ types:
       - FROM_TODAY
       - FROM_CUSTOM_DATE
 
+  BlobStorageExportSource:
+    enum:
+      - TRACES_OBSERVATIONS
+      - TRACES_OBSERVATIONS_EVENTS
+      - EVENTS
+
+  BlobStorageObservationFieldGroup:
+    enum:
+      - core
+      - basic
+      - time
+      - io
+      - metadata
+      - model
+      - usage
+      - prompt
+      - metrics
+
   BlobStorageExportFrequency:
     enum:
       - hourly
@@ -96,6 +114,15 @@ types:
       exportStartDate:
         type: optional<datetime>
         docs: Custom start date for exports (required when exportMode is FROM_CUSTOM_DATE)
+      exportSource:
+        type: optional<BlobStorageExportSource>
+        docs: Which observation source should be exported. Scores are always included.
+      exportFieldGroups:
+        type: optional<list<BlobStorageObservationFieldGroup>>
+        docs: Which observation field groups should be exported for observation-based exports.
+      compressed:
+        type: optional<boolean>
+        docs: Whether exported files should be gzip-compressed before upload.
 
   BlobStorageIntegrationResponse:
     properties:
@@ -113,6 +140,9 @@ types:
       fileType: BlobStorageIntegrationFileType
       exportMode: BlobStorageExportMode
       exportStartDate: nullable<datetime>
+      exportSource: BlobStorageExportSource
+      exportFieldGroups: nullable<list<BlobStorageObservationFieldGroup>>
+      compressed: boolean
       nextSyncAt: nullable<datetime>
       lastSyncAt: nullable<datetime>
       lastError: nullable<string>

--- a/packages/shared/prisma/generated/types.ts
+++ b/packages/shared/prisma/generated/types.ts
@@ -379,6 +379,8 @@ export type BlobStorageIntegration = {
   export_mode: Generated<BlobStorageExportMode>;
   export_start_date: Timestamp | null;
   export_source: Generated<AnalyticsIntegrationExportSource>;
+  export_field_groups: Generated<string[]>;
+  compressed: Generated<boolean>;
   last_error: string | null;
   last_error_at: Timestamp | null;
   created_at: Generated<Timestamp>;

--- a/packages/shared/prisma/migrations/20260622000000_add_blob_storage_export_fields/migration.sql
+++ b/packages/shared/prisma/migrations/20260622000000_add_blob_storage_export_fields/migration.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "blob_storage_integrations"
+ADD COLUMN "export_field_groups" TEXT[] NOT NULL DEFAULT ARRAY[
+  'core',
+  'basic',
+  'time',
+  'io',
+  'metadata',
+  'model',
+  'usage',
+  'prompt',
+  'metrics'
+],
+ADD COLUMN "compressed" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1126,6 +1126,8 @@ model BlobStorageIntegration {
   exportMode      BlobStorageExportMode            @default(FULL_HISTORY) @map("export_mode")
   exportStartDate DateTime?                        @map("export_start_date")
   exportSource    AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
+  exportFieldGroups String[]                       @default(["core", "basic", "time", "io", "metadata", "model", "usage", "prompt", "metrics"]) @map("export_field_groups")
+  compressed       Boolean                         @default(true) @map("compressed")
 
   // Error tracking
   lastError   String?   @map("last_error")

--- a/packages/shared/src/domain/index.ts
+++ b/packages/shared/src/domain/index.ts
@@ -1,4 +1,5 @@
 export * from "./observations";
+export * from "./observation-field-groups";
 export * from "./traces";
 export * from "./scores";
 export * from "./table-view-presets";

--- a/packages/shared/src/domain/observation-field-groups.ts
+++ b/packages/shared/src/domain/observation-field-groups.ts
@@ -1,0 +1,76 @@
+export const OBSERVATION_FIELD_GROUPS = [
+  "core",
+  "basic",
+  "time",
+  "io",
+  "metadata",
+  "model",
+  "usage",
+  "prompt",
+  "metrics",
+] as const;
+
+export type ObservationFieldGroup = (typeof OBSERVATION_FIELD_GROUPS)[number];
+
+export const DEFAULT_OBSERVATION_FIELD_GROUPS: ObservationFieldGroup[] = [
+  ...OBSERVATION_FIELD_GROUPS,
+];
+
+export const OBSERVATION_FIELD_GROUP_OPTIONS: Array<{
+  value: ObservationFieldGroup;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "core",
+    label: "Core",
+    description:
+      "Always-required identifiers and timestamps such as observation ID, trace ID, type, and start or end time.",
+  },
+  {
+    value: "basic",
+    label: "Basic",
+    description:
+      "Names, levels, environments, session or user references, and other general observation attributes.",
+  },
+  {
+    value: "time",
+    label: "Time",
+    description:
+      "Additional timing fields such as completion start time and record creation or update timestamps.",
+  },
+  {
+    value: "io",
+    label: "Input / Output",
+    description:
+      "Observation input and output payloads. Usually the largest part of the export.",
+  },
+  {
+    value: "metadata",
+    label: "Metadata",
+    description:
+      "Structured metadata attached to observations, including stored metadata arrays for enriched observations.",
+  },
+  {
+    value: "model",
+    label: "Model",
+    description: "Model names and parameters used by the observation.",
+  },
+  {
+    value: "usage",
+    label: "Usage & Cost",
+    description:
+      "Usage details, cost details, and aggregated total cost fields.",
+  },
+  {
+    value: "prompt",
+    label: "Prompt",
+    description:
+      "Prompt identifiers, names, and versions linked to the observation.",
+  },
+  {
+    value: "metrics",
+    label: "Metrics",
+    description: "Latency and time-to-first-token style performance metrics.",
+  },
+];

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1,5 +1,10 @@
 import { prisma } from "../../db";
-import { Observation, EventsObservation, ObservationType } from "../../domain";
+import {
+  Observation,
+  EventsObservation,
+  ObservationType,
+  type ObservationFieldGroup,
+} from "../../domain";
 import { env } from "../../env";
 import { InternalServerError, LangfuseNotFoundError } from "../../errors";
 import { recordDistribution } from "../instrumentation";
@@ -2748,6 +2753,7 @@ export const getEventsForBlobStorageExport = function (
     SELECT
       o.span_id AS id,
       o.trace_id,
+      o.project_id,
       o.name,
       o.type,
       o.level,
@@ -2757,6 +2763,8 @@ export const getEventsForBlobStorageExport = function (
       o.session_id,
       o.tags,
       o.${dq("release")},
+      o.${dq("public")},
+      o.bookmarked,
       o.trace_name,
       o.total_cost,
       if(o.end_time is null, null, milliseconds_diff(o.end_time, o.start_time)) as latency,
@@ -2767,8 +2775,16 @@ export const getEventsForBlobStorageExport = function (
       o.start_time,
       o.end_time,
       o.provided_model_name as model,
+      o.model_parameters,
+      o.usage_details,
+      o.cost_details,
+      o.completion_start_time,
+      o.created_at,
+      o.updated_at,
+      o.prompt_id,
       o.prompt_name,
       o.prompt_version,
+      if(o.completion_start_time is null, null, milliseconds_diff(o.completion_start_time, o.start_time)) as time_to_first_token,
       o.status_message,
       o.parent_span_id AS parent_observation_id,
       o.version as event_version

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1655,15 +1655,32 @@ export const getObservationsForBlobStorageExport = function (
         level,
         status_message,
         version,
+        user_id,
+        session_id,
+        tags,
+        ${dq("release")},
+        ${dq("public")},
+        bookmarked,
+        trace_name,
         input,
         output,
-        provided_model_name,
+        provided_model_name as model,
         model_parameters,
         usage_details,
         cost_details,
+        total_cost,
         completion_start_time,
+        created_at,
+        updated_at,
+        prompt_id,
         prompt_name,
-        prompt_version
+        prompt_version,
+        CASE WHEN end_time IS NULL THEN NULL
+             ELSE milliseconds_diff(end_time, start_time)
+        END as latency,
+        CASE WHEN completion_start_time IS NULL THEN NULL
+             ELSE milliseconds_diff(completion_start_time, start_time)
+        END as time_to_first_token
       FROM events_full
       WHERE project_id = {projectId: String}
       AND start_time >= {minTimestamp: DateTime}

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -43,6 +43,21 @@ const BlobStorageIntegrationDeletionResponseSchema = z.object({
   message: z.string(),
 });
 
+const BlobStorageIntegrationExtendedResponseSchema =
+  BlobStorageIntegrationResponseSchema.extend({
+    exportSource: z.enum([
+      "TRACES_OBSERVATIONS",
+      "TRACES_OBSERVATIONS_EVENTS",
+      "EVENTS",
+    ]),
+    exportFieldGroups: z.array(z.string()).nullable(),
+    compressed: z.boolean(),
+  });
+
+const BlobStorageIntegrationsExtendedResponseSchema = z.object({
+  data: z.array(BlobStorageIntegrationExtendedResponseSchema),
+});
+
 // Valid blob storage integration request payload
 const validBlobStorageConfig = {
   projectId: "",
@@ -276,6 +291,52 @@ describe("Blob Storage Integrations API", () => {
       });
       expect(savedIntegration).toBeDefined();
       expect(savedIntegration?.bucketName).toBe("test-bucket");
+    });
+
+    it("should round-trip exportSource, exportFieldGroups, and compressed settings", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "EVENTS" as const,
+        exportFieldGroups: ["core", "io"],
+        compressed: false,
+      };
+
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationExtendedResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+
+      expect(putResponse.body.exportSource).toBe("EVENTS");
+      expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
+      expect(putResponse.body.compressed).toBe(false);
+
+      const getResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationsExtendedResponseSchema,
+        "GET",
+        "/api/public/integrations/blob-storage",
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+
+      const integration = getResponse.body.data.find(
+        (item) => item.projectId === testProject1Id,
+      );
+      expect(integration?.exportSource).toBe("EVENTS");
+      expect(integration?.exportFieldGroups).toStrictEqual(["core", "io"]);
+      expect(integration?.compressed).toBe(false);
+
+      const savedIntegration = (await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      })) as any;
+      expect(savedIntegration?.exportSource).toBe("EVENTS");
+      expect(savedIntegration?.exportFieldGroups).toStrictEqual(["core", "io"]);
+      expect(savedIntegration?.compressed).toBe(false);
     });
 
     it("should update an existing blob storage integration", async () => {

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -6,8 +6,8 @@ import {
   createTRPCRouter,
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
-import { encrypt } from "@langfuse/shared/encryption";
 import { blobStorageIntegrationFormSchema } from "@/src/features/blobstorage-integration/types";
+import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { TRPCError } from "@trpc/server";
 import {
   logger,
@@ -18,11 +18,9 @@ import {
 import { randomUUID } from "crypto";
 import { decrypt } from "@langfuse/shared/encryption";
 import {
-  type BlobStorageIntegration,
   BlobStorageIntegrationType,
-  BlobStorageExportMode,
+  InvalidRequestError,
 } from "@langfuse/shared";
-import { env } from "@/src/env.mjs";
 
 export const blobStorageIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure
@@ -72,114 +70,37 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           resourceType: "blobStorageIntegration",
           resourceId: input.projectId,
         });
-
-        // Extract data from input
-        const {
-          accessKeyId,
-          secretAccessKey,
-          type,
-          bucketName,
-          endpoint,
-          region,
-          prefix,
-          exportFrequency,
-          enabled,
-          forcePathStyle,
-          fileType,
-          exportMode,
-          exportStartDate,
-          exportSource,
-        } = input;
-
-        const isSelfHosted = !env.NEXT_PUBLIC_LITEFUSE_CLOUD_REGION;
-        const canUseHostCredentials =
-          isSelfHosted && type === BlobStorageIntegrationType.S3;
-        const isUsingHostCredentials =
-          canUseHostCredentials && (!accessKeyId || !secretAccessKey);
-
-        if (!canUseHostCredentials && !accessKeyId) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Access Key ID and Secret Access Key are required",
-          });
-        }
-
-        // Determine the export start date based on export mode
-        let finalExportStartDate: Date | null = null;
-        if (exportMode === BlobStorageExportMode.FROM_TODAY) {
-          finalExportStartDate = new Date();
-        } else if (exportMode === BlobStorageExportMode.FROM_CUSTOM_DATE) {
-          finalExportStartDate = exportStartDate || new Date();
-        }
-        // For FULL_HISTORY mode, exportStartDate remains null
-
-        // AWS S3 uses the standard endpoint; custom endpoint is only for S3-compatible providers
-        const normalizedEndpoint =
-          type === BlobStorageIntegrationType.S3 ? null : endpoint || null;
-
-        const data: Partial<BlobStorageIntegration> = {
-          type,
-          bucketName,
-          endpoint: normalizedEndpoint,
-          region,
-          prefix: prefix ?? "",
-          exportFrequency,
-          enabled,
-          accessKeyId,
-          forcePathStyle: forcePathStyle || false,
-          fileType,
-          exportMode,
-          exportStartDate: finalExportStartDate,
-          exportSource,
-        };
-
-        // Use a transaction to check if record exists, then create or update
-        return await ctx.prisma.$transaction(async (prisma) => {
-          // Check if a record exists for this project
-          const existingConfig = await prisma.blobStorageIntegration.findUnique(
-            {
-              where: {
-                projectId: input.projectId,
-              },
-            },
-          );
-
-          if (existingConfig) {
-            if (secretAccessKey) {
-              data.secretAccessKey = encrypt(secretAccessKey);
-            }
-
-            return await prisma.blobStorageIntegration.update({
-              where: {
-                projectId: input.projectId,
-              },
-              data,
-            });
-          } else {
-            // Record doesn't exist, perform create
-            if (!isUsingHostCredentials && !secretAccessKey) {
-              throw new TRPCError({
-                code: "BAD_REQUEST",
-                message:
-                  "Secret access key is required for new configuration when not using host credentials",
-              });
-            }
-
-            return await prisma.blobStorageIntegration.create({
-              data: {
-                ...(data as BlobStorageIntegration),
-                projectId: input.projectId,
-                accessKeyId,
-                secretAccessKey: secretAccessKey
-                  ? encrypt(secretAccessKey)
-                  : undefined,
-              },
-            });
-          }
+        return await upsertBlobStorageIntegration({
+          prisma: ctx.prisma,
+          projectId: input.projectId,
+          data: {
+            type: input.type,
+            bucketName: input.bucketName,
+            endpoint: input.endpoint || null,
+            region: input.region,
+            accessKeyId: input.accessKeyId || null,
+            secretAccessKey: input.secretAccessKey ?? null,
+            prefix: input.prefix ?? "",
+            exportFrequency: input.exportFrequency,
+            enabled: input.enabled,
+            forcePathStyle: input.forcePathStyle || false,
+            fileType: input.fileType,
+            exportMode: input.exportMode,
+            exportStartDate: input.exportStartDate ?? null,
+            exportSource: input.exportSource,
+            exportFieldGroups: input.exportFieldGroups,
+            compressed: input.compressed,
+          },
         });
       } catch (e) {
         if (e instanceof TRPCError) {
           throw e;
+        }
+        if (e instanceof InvalidRequestError) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: e.message,
+          });
         }
         logger.error(`Failed to update blob storage integration`, e);
         throw new TRPCError({

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -1,0 +1,137 @@
+import { type PrismaClient } from "@langfuse/shared/src/db";
+import {
+  BlobStorageExportMode,
+  BlobStorageIntegrationType,
+  InvalidRequestError,
+  type BlobStorageIntegrationFileType,
+  type AnalyticsIntegrationExportSource,
+  type ObservationFieldGroup,
+  DEFAULT_OBSERVATION_FIELD_GROUPS,
+} from "@langfuse/shared";
+import { encrypt } from "@langfuse/shared/encryption";
+import { env } from "@/src/env.mjs";
+
+type UpsertBlobStorageIntegrationInput = {
+  type: BlobStorageIntegrationType;
+  bucketName: string;
+  endpoint: string | null;
+  region: string;
+  accessKeyId: string | null;
+  secretAccessKey: string | null;
+  prefix: string;
+  exportFrequency: string;
+  enabled: boolean;
+  forcePathStyle: boolean;
+  fileType: BlobStorageIntegrationFileType;
+  exportMode: BlobStorageExportMode;
+  exportStartDate: Date | null;
+  exportSource: AnalyticsIntegrationExportSource;
+  exportFieldGroups: ObservationFieldGroup[];
+  compressed: boolean;
+};
+
+function resolveExportStartDate(params: {
+  exportMode: BlobStorageExportMode;
+  exportStartDate: Date | null;
+}): Date | null {
+  switch (params.exportMode) {
+    case BlobStorageExportMode.FROM_TODAY:
+      return new Date();
+    case BlobStorageExportMode.FROM_CUSTOM_DATE:
+      return params.exportStartDate || new Date();
+    case BlobStorageExportMode.FULL_HISTORY:
+      return null;
+    default: {
+      const _exhaustive: never = params.exportMode;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
+
+export async function upsertBlobStorageIntegration(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  data: UpsertBlobStorageIntegrationInput;
+}) {
+  const { prisma, projectId, data } = params;
+
+  const normalizedAccessKeyId = data.accessKeyId || null;
+  const normalizedSecretAccessKey = data.secretAccessKey || null;
+  const normalizedEndpoint =
+    data.type === BlobStorageIntegrationType.S3 ? null : data.endpoint || null;
+
+  const isSelfHosted = !env.NEXT_PUBLIC_LITEFUSE_CLOUD_REGION;
+  const canUseHostCredentials =
+    isSelfHosted && data.type === BlobStorageIntegrationType.S3;
+
+  if (!canUseHostCredentials && !normalizedAccessKeyId) {
+    throw new InvalidRequestError(
+      "Access Key ID and Secret Access Key are required",
+    );
+  }
+
+  const resolvedExportStartDate = resolveExportStartDate({
+    exportMode: data.exportMode,
+    exportStartDate: data.exportStartDate,
+  });
+
+  const writeData = {
+    type: data.type,
+    bucketName: data.bucketName,
+    endpoint: normalizedEndpoint,
+    region: data.region,
+    accessKeyId: normalizedAccessKeyId,
+    prefix: data.prefix,
+    exportFrequency: data.exportFrequency,
+    enabled: data.enabled,
+    forcePathStyle: data.forcePathStyle,
+    fileType: data.fileType,
+    exportMode: data.exportMode,
+    exportStartDate: resolvedExportStartDate,
+    exportSource: data.exportSource,
+    exportFieldGroups:
+      data.exportFieldGroups.length > 0
+        ? data.exportFieldGroups
+        : DEFAULT_OBSERVATION_FIELD_GROUPS,
+    compressed: data.compressed,
+  };
+
+  return prisma.$transaction(async (tx) => {
+    const existing = await tx.blobStorageIntegration.findUnique({
+      where: { projectId },
+      select: { exportMode: true },
+    });
+
+    if (!existing) {
+      const isUsingHostCredentials =
+        canUseHostCredentials &&
+        (!normalizedAccessKeyId || !normalizedSecretAccessKey);
+
+      if (!isUsingHostCredentials && !normalizedSecretAccessKey) {
+        throw new InvalidRequestError(
+          "Secret access key is required for new configuration",
+        );
+      }
+    }
+
+    const modeChanged = existing?.exportMode !== data.exportMode;
+    const encryptedSecret = normalizedSecretAccessKey
+      ? encrypt(normalizedSecretAccessKey)
+      : null;
+
+    return tx.blobStorageIntegration.upsert({
+      where: { projectId },
+      create: {
+        ...writeData,
+        projectId,
+        secretAccessKey: encryptedSecret,
+      },
+      update: {
+        ...writeData,
+        ...(encryptedSecret ? { secretAccessKey: encryptedSecret } : {}),
+        ...(modeChanged ? { lastSyncAt: null, nextSyncAt: null } : {}),
+      },
+    });
+  });
+}

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -4,9 +4,12 @@ import {
   BlobStorageIntegrationFileType,
   BlobStorageExportMode,
   AnalyticsIntegrationExportSource,
+  OBSERVATION_FIELD_GROUPS,
+  DEFAULT_OBSERVATION_FIELD_GROUPS,
 } from "@langfuse/shared";
+import { validateBlobStorageIntegrationConfig } from "@/src/features/blobstorage-integration/validation";
 
-export const blobStorageIntegrationFormSchema = z.object({
+export const blobStorageIntegrationFormSchemaBase = z.object({
   type: z.enum(BlobStorageIntegrationType),
   bucketName: z.string().min(1, { message: "Bucket name is required" }),
   endpoint: z.string().url().optional().nullable(),
@@ -33,7 +36,23 @@ export const blobStorageIntegrationFormSchema = z.object({
   exportSource: z
     .enum(AnalyticsIntegrationExportSource)
     .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+  exportFieldGroups: z
+    .array(z.enum(OBSERVATION_FIELD_GROUPS))
+    .default(DEFAULT_OBSERVATION_FIELD_GROUPS),
+  compressed: z.boolean().default(true),
 });
+
+export const blobStorageIntegrationFormSchema =
+  blobStorageIntegrationFormSchemaBase.superRefine((data, ctx) => {
+    if (data.exportMode === "FROM_CUSTOM_DATE" && !data.exportStartDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Export start date is required for custom date exports",
+        path: ["exportStartDate"],
+      });
+    }
+    validateBlobStorageIntegrationConfig(data, ctx);
+  });
 
 export type BlobStorageIntegrationFormSchema = z.infer<
   typeof blobStorageIntegrationFormSchema

--- a/web/src/features/blobstorage-integration/validation.ts
+++ b/web/src/features/blobstorage-integration/validation.ts
@@ -1,0 +1,80 @@
+import {
+  type ObservationFieldGroup,
+  OBSERVATION_FIELD_GROUPS,
+} from "@langfuse/shared";
+import { z } from "zod/v4";
+
+/**
+ * Azure container names must be 3-63 characters, lowercase letters, numbers,
+ * and hyphens only. Must start and end with a letter or number. No consecutive
+ * hyphens.
+ *
+ * @see https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names
+ */
+export const AZURE_CONTAINER_NAME_REGEX =
+  /^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$/;
+
+export const AZURE_CONTAINER_NAME_ERROR =
+  "Azure container names must be 3-63 characters, lowercase letters, numbers, and hyphens only. Must start and end with a letter or number, no consecutive hyphens.";
+
+export function validateAzureContainerName(
+  data: { type: string; bucketName: string },
+  ctx: z.RefinementCtx,
+) {
+  if (!data.bucketName) return;
+  if (
+    data.type === "AZURE_BLOB_STORAGE" &&
+    !AZURE_CONTAINER_NAME_REGEX.test(data.bucketName)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: AZURE_CONTAINER_NAME_ERROR,
+      path: ["bucketName"],
+    });
+  }
+}
+
+export function validateBlobStorageExportFieldGroups(
+  exportFieldGroups: ObservationFieldGroup[] | undefined,
+  ctx: z.RefinementCtx,
+) {
+  if (!exportFieldGroups?.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "At least one export field group must be selected",
+      path: ["exportFieldGroups"],
+    });
+    return;
+  }
+
+  if (!exportFieldGroups.includes("core")) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "The core export field group is required",
+      path: ["exportFieldGroups"],
+    });
+  }
+
+  const invalidGroups = exportFieldGroups.filter(
+    (group) => !OBSERVATION_FIELD_GROUPS.includes(group),
+  );
+  if (invalidGroups.length > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Invalid export field group selection: ${invalidGroups.join(", ")}`,
+      path: ["exportFieldGroups"],
+    });
+  }
+}
+
+export function validateBlobStorageIntegrationConfig(
+  data: {
+    type: string;
+    bucketName: string;
+    exportFieldGroups?: ObservationFieldGroup[];
+  },
+  ctx: z.RefinementCtx,
+) {
+  validateAzureContainerName(data, ctx);
+  validateBlobStorageExportFieldGroups(data.exportFieldGroups, ctx);
+}

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -1,4 +1,10 @@
 import { z } from "zod/v4";
+import {
+  AnalyticsIntegrationExportSource,
+  DEFAULT_OBSERVATION_FIELD_GROUPS,
+  OBSERVATION_FIELD_GROUPS,
+} from "@langfuse/shared";
+import { validateBlobStorageIntegrationConfig } from "@/src/features/blobstorage-integration/validation";
 
 /**
  * Enums
@@ -45,18 +51,26 @@ export const CreateBlobStorageIntegrationRequest = z
     fileType: BlobStorageIntegrationFileType,
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable().optional(),
+    exportSource: z
+      .enum(AnalyticsIntegrationExportSource)
+      .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+    exportFieldGroups: z
+      .array(z.enum(OBSERVATION_FIELD_GROUPS))
+      .default(DEFAULT_OBSERVATION_FIELD_GROUPS),
+    compressed: z.boolean().default(true),
   })
   .strict()
-  .refine(
-    (data) => {
-      return !(data.exportMode === "FROM_CUSTOM_DATE" && !data.exportStartDate);
-    },
-    {
-      message:
-        "exportStartDate is required when exportMode is FROM_CUSTOM_DATE",
-      path: ["exportStartDate"],
-    },
-  );
+  .superRefine((data, ctx) => {
+    if (data.exportMode === "FROM_CUSTOM_DATE" && !data.exportStartDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "exportStartDate is required when exportMode is FROM_CUSTOM_DATE",
+        path: ["exportStartDate"],
+      });
+    }
+    validateBlobStorageIntegrationConfig(data, ctx);
+  });
 
 export const BlobStorageIntegrationResponse = z
   .object({
@@ -74,6 +88,9 @@ export const BlobStorageIntegrationResponse = z
     fileType: BlobStorageIntegrationFileType,
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable(),
+    exportSource: z.enum(AnalyticsIntegrationExportSource),
+    exportFieldGroups: z.array(z.enum(OBSERVATION_FIELD_GROUPS)).nullable(),
+    compressed: z.boolean(),
     nextSyncAt: z.coerce.date().nullable(),
     lastSyncAt: z.coerce.date().nullable(),
     lastError: z.string().nullable(),

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -2,18 +2,18 @@ import {
   type Observation,
   type EventsObservation,
   ObservationLevel,
+  OBSERVATION_FIELD_GROUPS,
   paginationMetaResponseZod,
   publicApiPaginationZod,
   singleFilter,
   InvalidRequestError,
+  type ObservationFieldGroup,
 } from "@langfuse/shared";
 
 import {
   reduceUsageOrCostDetails,
   stringDateTime,
   type ObservationPriceFields,
-  OBSERVATION_FIELD_GROUPS,
-  type ObservationFieldGroup,
 } from "@langfuse/shared/src/server";
 import { z } from "zod/v4";
 import { useEventsTableSchema } from "../../query/types";

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -8,12 +8,38 @@ import {
   CreateBlobStorageIntegrationRequest,
   type BlobStorageIntegrationResponseType,
 } from "@/src/features/public-api/types/blob-storage-integrations";
+import { OBSERVATION_FIELD_GROUPS } from "@langfuse/shared";
 import {
   LangfuseNotFoundError,
   UnauthorizedError,
   ForbiddenError,
 } from "@langfuse/shared";
-import { encrypt } from "@langfuse/shared/encryption";
+import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
+
+type BlobStorageIntegrationResponseInput = Omit<
+  BlobStorageIntegrationResponseType,
+  "id" | "exportFieldGroups" | "compressed"
+> & {
+  exportFieldGroups?: string[] | null;
+  compressed?: boolean | null;
+};
+
+function toBlobStorageIntegrationResponse(
+  integration: BlobStorageIntegrationResponseInput,
+): BlobStorageIntegrationResponseType {
+  return {
+    id: integration.projectId,
+    ...integration,
+    exportFieldGroups:
+      integration.exportFieldGroups?.filter(
+        (group): group is (typeof OBSERVATION_FIELD_GROUPS)[number] =>
+          OBSERVATION_FIELD_GROUPS.includes(
+            group as (typeof OBSERVATION_FIELD_GROUPS)[number],
+          ),
+      ) ?? null,
+    compressed: integration.compressed ?? true,
+  };
+}
 
 export default withMiddlewares({
   GET: handleGetBlobStorageIntegrations,
@@ -70,28 +96,7 @@ async function handleGetBlobStorageIntegrations(
 
   // Transform to API response format, exclude secretAccessKey
   const responseData: BlobStorageIntegrationResponseType[] = integrations.map(
-    (integration) => ({
-      id: integration.projectId, // Using projectId as ID since it's the primary key
-      projectId: integration.projectId,
-      type: integration.type,
-      bucketName: integration.bucketName,
-      endpoint: integration.endpoint,
-      region: integration.region,
-      accessKeyId: integration.accessKeyId,
-      prefix: integration.prefix,
-      exportFrequency: integration.exportFrequency,
-      enabled: integration.enabled,
-      forcePathStyle: integration.forcePathStyle,
-      fileType: integration.fileType,
-      exportMode: integration.exportMode,
-      exportStartDate: integration.exportStartDate,
-      nextSyncAt: integration.nextSyncAt,
-      lastSyncAt: integration.lastSyncAt,
-      lastError: integration.lastError,
-      lastErrorAt: integration.lastErrorAt,
-      createdAt: integration.createdAt,
-      updatedAt: integration.updatedAt,
-    }),
+    toBlobStorageIntegrationResponse,
   );
 
   return res.status(200).json({
@@ -146,56 +151,28 @@ async function handleUpsertBlobStorageIntegration(
     throw new LangfuseNotFoundError("Project not found");
   }
 
-  // Prepare data for database
-  const dbData = {
+  const integration = await upsertBlobStorageIntegration({
+    prisma,
     projectId: validatedData.projectId,
-    type: validatedData.type,
-    bucketName: validatedData.bucketName,
-    endpoint: validatedData.endpoint || null,
-    region: validatedData.region,
-    accessKeyId: validatedData.accessKeyId || null,
-    secretAccessKey: validatedData.secretAccessKey
-      ? encrypt(validatedData.secretAccessKey)
-      : null,
-    prefix: validatedData.prefix,
-    exportFrequency: validatedData.exportFrequency,
-    enabled: validatedData.enabled,
-    forcePathStyle: validatedData.forcePathStyle,
-    fileType: validatedData.fileType,
-    exportMode: validatedData.exportMode,
-    exportStartDate: validatedData.exportStartDate || null,
-  };
-
-  // Upsert the integration (create or update)
-  const integration = await prisma.blobStorageIntegration.upsert({
-    where: { projectId: validatedData.projectId },
-    update: dbData,
-    create: dbData,
+    data: {
+      type: validatedData.type,
+      bucketName: validatedData.bucketName,
+      endpoint: validatedData.endpoint || null,
+      region: validatedData.region,
+      accessKeyId: validatedData.accessKeyId || null,
+      secretAccessKey: validatedData.secretAccessKey ?? null,
+      prefix: validatedData.prefix,
+      exportFrequency: validatedData.exportFrequency,
+      enabled: validatedData.enabled,
+      forcePathStyle: validatedData.forcePathStyle,
+      fileType: validatedData.fileType,
+      exportMode: validatedData.exportMode,
+      exportStartDate: validatedData.exportStartDate || null,
+      exportSource: validatedData.exportSource,
+      exportFieldGroups: validatedData.exportFieldGroups,
+      compressed: validatedData.compressed,
+    },
   });
 
-  // Transform to API response format, exclude secretAccessKey
-  const responseData: BlobStorageIntegrationResponseType = {
-    id: integration.projectId, // Using projectId as ID since it's the primary key
-    projectId: integration.projectId,
-    type: integration.type,
-    bucketName: integration.bucketName,
-    endpoint: integration.endpoint,
-    region: integration.region,
-    accessKeyId: integration.accessKeyId,
-    prefix: integration.prefix,
-    exportFrequency: integration.exportFrequency,
-    enabled: integration.enabled,
-    forcePathStyle: integration.forcePathStyle,
-    fileType: integration.fileType,
-    exportMode: integration.exportMode,
-    exportStartDate: integration.exportStartDate,
-    nextSyncAt: integration.nextSyncAt,
-    lastSyncAt: integration.lastSyncAt,
-    lastError: integration.lastError,
-    lastErrorAt: integration.lastErrorAt,
-    createdAt: integration.createdAt,
-    updatedAt: integration.updatedAt,
-  };
-
-  return res.status(200).json(responseData);
+  return res.status(200).json(toBlobStorageIntegrationResponse(integration));
 }

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -20,6 +20,7 @@ type BlobStorageIntegrationResponseInput = Omit<
   BlobStorageIntegrationResponseType,
   "id" | "exportFieldGroups" | "compressed"
 > & {
+  secretAccessKey?: string | null;
   exportFieldGroups?: string[] | null;
   compressed?: boolean | null;
 };
@@ -27,17 +28,19 @@ type BlobStorageIntegrationResponseInput = Omit<
 function toBlobStorageIntegrationResponse(
   integration: BlobStorageIntegrationResponseInput,
 ): BlobStorageIntegrationResponseType {
+  const { secretAccessKey: _secretAccessKey, ...safeIntegration } = integration;
+
   return {
-    id: integration.projectId,
-    ...integration,
+    id: safeIntegration.projectId,
+    ...safeIntegration,
     exportFieldGroups:
-      integration.exportFieldGroups?.filter(
+      safeIntegration.exportFieldGroups?.filter(
         (group): group is (typeof OBSERVATION_FIELD_GROUPS)[number] =>
           OBSERVATION_FIELD_GROUPS.includes(
             group as (typeof OBSERVATION_FIELD_GROUPS)[number],
           ),
       ) ?? null,
-    compressed: integration.compressed ?? true,
+    compressed: safeIntegration.compressed ?? true,
   };
 }
 

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from "@/src/components/ui/input";
 import { PasswordInput } from "@/src/components/ui/password-input";
 import { Switch } from "@/src/components/ui/switch";
+import { Checkbox } from "@/src/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -35,7 +36,7 @@ import {
 import { deriveSyncStatus } from "@/src/features/blobstorage-integration/deriveSyncStatus";
 import { Alert, AlertTitle, AlertDescription } from "@/src/components/ui/alert";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
-import { api } from "@/src/utils/api";
+import { api, type RouterOutputs } from "@/src/utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Card } from "@/src/components/ui/card";
 import Link from "next/link";
@@ -49,12 +50,23 @@ import {
   BlobStorageIntegrationFileType,
   BlobStorageExportMode,
   AnalyticsIntegrationExportSource,
-  type BlobStorageIntegration,
+  DEFAULT_OBSERVATION_FIELD_GROUPS,
+  OBSERVATION_FIELD_GROUPS,
+  OBSERVATION_FIELD_GROUP_OPTIONS,
+  type ObservationFieldGroup,
   EXPORT_SOURCE_OPTIONS,
 } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { Info, ExternalLink } from "lucide-react";
+
+type BlobStorageIntegrationSettingsState = Omit<
+  NonNullable<RouterOutputs["blobStorageIntegration"]["get"]>,
+  "exportFieldGroups" | "compressed"
+> & {
+  exportFieldGroups: ObservationFieldGroup[] | null;
+  compressed: boolean;
+  secretAccessKey?: string | null;
+};
 
 export default function BlobStorageIntegrationSettings() {
   const router = useRouter();
@@ -206,7 +218,10 @@ export default function BlobStorageIntegrationSettings() {
           <Header title="Configuration" className="mt-8" />
           <Card className="p-3">
             <BlobStorageIntegrationSettingsForm
-              state={state.data || undefined}
+              state={
+                (state.data as BlobStorageIntegrationSettingsState | null) ??
+                undefined
+              }
               projectId={projectId}
               isLoading={state.isLoading}
             />
@@ -222,18 +237,19 @@ const BlobStorageIntegrationSettingsForm = ({
   projectId,
   isLoading,
 }: {
-  state?: Partial<BlobStorageIntegration>;
+  state?: Partial<BlobStorageIntegrationSettingsState>;
   projectId: string;
   isLoading: boolean;
 }) => {
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
-  const { isBetaEnabled } = useV4Beta();
   const [integrationType, setIntegrationType] =
     useState<BlobStorageIntegrationType>(BlobStorageIntegrationType.S3);
 
   // Check if this is a self-hosted instance (no cloud region set)
   const isSelfHosted = !isLangfuseCloud;
+  const defaultExportFieldGroups =
+    state?.exportFieldGroups ?? DEFAULT_OBSERVATION_FIELD_GROUPS;
 
   const blobStorageForm = useForm({
     resolver: zodResolver(blobStorageIntegrationFormSchema),
@@ -256,9 +272,9 @@ const BlobStorageIntegrationSettingsForm = ({
       exportStartDate: state?.exportStartDate || null,
       exportSource:
         state?.exportSource ||
-        (isBetaEnabled
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      exportFieldGroups: defaultExportFieldGroups,
+      compressed: state?.compressed ?? true,
     },
     disabled: isLoading,
   });
@@ -284,9 +300,9 @@ const BlobStorageIntegrationSettingsForm = ({
       exportStartDate: state?.exportStartDate || null,
       exportSource:
         state?.exportSource ||
-        (isBetaEnabled
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      exportFieldGroups: defaultExportFieldGroups,
+      compressed: state?.compressed ?? true,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
@@ -654,67 +670,147 @@ const BlobStorageIntegrationSettingsForm = ({
           )}
         />
 
-        {isBetaEnabled && (
-          <FormField
-            control={blobStorageForm.control}
-            name="exportSource"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel className="flex items-center gap-1.5 pt-2">
-                  Export Source
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <Info className="text-muted-foreground h-3.5 w-3.5" />
-                    </TooltipTrigger>
-                    <TooltipContent
-                      side="bottom"
-                      className="max-w-[350px] space-y-2 p-3"
-                    >
-                      {EXPORT_SOURCE_OPTIONS.map((option) => (
-                        <div key={option.value} className="space-y-0.5">
-                          <div className="font-medium">{option.label}</div>
-                          <div className="text-muted-foreground text-xs">
-                            {option.description}
-                          </div>
-                        </div>
-                      ))}
-                      <div className="border-t pt-2">
-                        <a
-                          href="https://litefuse.ai/docs/integrations/export-sources"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-muted-foreground hover:text-primary inline-flex items-center gap-1 text-xs hover:underline"
-                        >
-                          For further information see
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
-                      </div>
-                    </TooltipContent>
-                  </Tooltip>
-                </FormLabel>
-                <Select onValueChange={field.onChange} value={field.value}>
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select data to export" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
+        <FormField
+          control={blobStorageForm.control}
+          name="exportSource"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="flex items-center gap-1.5 pt-2">
+                Export Source
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Info className="text-muted-foreground h-3.5 w-3.5" />
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="bottom"
+                    className="max-w-[350px] space-y-2 p-3"
+                  >
                     {EXPORT_SOURCE_OPTIONS.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
+                      <div key={option.value} className="space-y-0.5">
+                        <div className="font-medium">{option.label}</div>
+                        <div className="text-muted-foreground text-xs">
+                          {option.description}
+                        </div>
+                      </div>
                     ))}
-                  </SelectContent>
-                </Select>
-                <FormDescription>
-                  Choose which data sources to export to blob storage. Scores
-                  are always included.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        )}
+                    <div className="border-t pt-2">
+                      <a
+                        href="https://litefuse.ai/docs/integrations/export-sources"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-muted-foreground hover:text-primary inline-flex items-center gap-1 text-xs hover:underline"
+                      >
+                        For further information see
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select data to export" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {EXPORT_SOURCE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription>
+                Choose which data sources to export to blob storage. Scores are
+                always included.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={blobStorageForm.control}
+          name="exportFieldGroups"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Observation Field Groups</FormLabel>
+              <FormDescription>
+                Choose which observation fields to include in observation
+                exports. The core group is always required.
+              </FormDescription>
+              <div className="grid gap-3 pt-2 sm:grid-cols-2">
+                {OBSERVATION_FIELD_GROUP_OPTIONS.map((option) => {
+                  const selectedFieldGroups =
+                    (field.value as ObservationFieldGroup[] | undefined) ??
+                    DEFAULT_OBSERVATION_FIELD_GROUPS;
+                  const checked = selectedFieldGroups.includes(option.value);
+                  const isRequired = option.value === "core";
+
+                  return (
+                    <label
+                      key={option.value}
+                      className="flex items-start gap-3 rounded-md border p-3"
+                    >
+                      <Checkbox
+                        checked={checked}
+                        disabled={isRequired}
+                        onCheckedChange={(nextChecked) => {
+                          if (isRequired) return;
+
+                          const nextValues = nextChecked
+                            ? OBSERVATION_FIELD_GROUPS.filter((group) =>
+                                [...selectedFieldGroups, option.value].includes(
+                                  group,
+                                ),
+                              )
+                            : selectedFieldGroups.filter(
+                                (value) => value !== option.value,
+                              );
+
+                          field.onChange(nextValues);
+                        }}
+                      />
+                      <div className="space-y-1">
+                        <div className="text-sm leading-none font-medium">
+                          {option.label}
+                          {isRequired ? " (required)" : ""}
+                        </div>
+                        <div className="text-muted-foreground text-xs">
+                          {option.description}
+                        </div>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={blobStorageForm.control}
+          name="compressed"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Gzip Compression</FormLabel>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  className="mt-1 ml-4"
+                />
+              </FormControl>
+              <FormDescription>
+                Compress exported files with gzip before uploading them to blob
+                storage.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         {blobStorageForm.watch("exportMode") ===
           BlobStorageExportMode.FROM_CUSTOM_DATE && (

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -3,16 +3,18 @@ import { env } from "../env";
 import { randomUUID } from "crypto";
 import {
   createObservation,
-  createObservationsCh,
   createOrgProjectAndApiKey,
   createTraceScore,
-  createScoresCh,
   createTrace,
-  createTracesCh,
   createEvent,
-  createEventsCh,
+  dorisClient,
+  formatDataForDoris,
   StorageService,
   StorageServiceFactory,
+  type EventRecordInsertType,
+  type ObservationRecordInsertType,
+  type ScoreRecordInsertType,
+  type TraceRecordInsertType,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { Job } from "bullmq";
@@ -32,6 +34,133 @@ const maybeDescribe =
   process.env.LITEFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true"
     ? describe
     : describe.skip;
+
+const dorisStreamLoadClient = dorisClient({
+  feHttpUrl: process.env.TEST_DORIS_STREAM_LOAD_URL ?? env.DORIS_FE_HTTP_URL,
+  feQueryPort: env.DORIS_FE_QUERY_PORT,
+  database: env.DORIS_DB,
+  username: env.DORIS_USER,
+  password: env.DORIS_PASSWORD,
+});
+
+const normalizeDorisTimestamp = (timestamp: unknown) =>
+  typeof timestamp === "number" && timestamp > 10_000_000_000_000
+    ? Math.trunc(timestamp / 1000)
+    : timestamp;
+
+const normalizeEventRecordTimestamps = (event: Record<string, unknown>) => ({
+  ...event,
+  start_time: normalizeDorisTimestamp(event.start_time),
+  end_time: normalizeDorisTimestamp(event.end_time),
+  completion_start_time: normalizeDorisTimestamp(event.completion_start_time),
+  created_at: normalizeDorisTimestamp(event.created_at),
+  updated_at: normalizeDorisTimestamp(event.updated_at),
+  event_ts: normalizeDorisTimestamp(event.event_ts),
+});
+
+const streamLoad = async (
+  table: "events_full" | "scores",
+  values: Record<string, unknown>[],
+) =>
+  await dorisStreamLoadClient.streamLoad(
+    table,
+    formatDataForDoris(values, table),
+    {
+      format: "json",
+      strip_outer_array: true,
+      read_json_by_line: false,
+      max_filter_ratio: 0.1,
+      timeout: 600,
+    },
+  );
+
+const createTracesCh = async (traces: TraceRecordInsertType[]) => {
+  const values = traces.map((trace) =>
+    createEvent({
+      project_id: trace.project_id,
+      trace_id: trace.id,
+      id: trace.id,
+      span_id: trace.id,
+      parent_span_id: "",
+      name: trace.name ?? "test-trace",
+      trace_name: trace.name ?? null,
+      type: "SPAN",
+      environment: trace.environment,
+      metadata: trace.metadata,
+      user_id: trace.user_id,
+      session_id: trace.session_id,
+      release: trace.release,
+      version: trace.version,
+      tags: trace.tags,
+      bookmarked: trace.bookmarked,
+      public: trace.public,
+      input: trace.input,
+      output: trace.output,
+      start_time: trace.timestamp,
+      created_at: trace.created_at,
+      updated_at: trace.updated_at,
+      event_ts: trace.event_ts,
+    }),
+  );
+
+  return await streamLoad("events_full", values);
+};
+
+const createObservationsCh = async (
+  observations: ObservationRecordInsertType[],
+) => {
+  const values = observations.map((observation) =>
+    createEvent({
+      project_id: observation.project_id,
+      trace_id: observation.trace_id ?? randomUUID(),
+      id: observation.id,
+      span_id: observation.id,
+      parent_span_id:
+        observation.parent_observation_id ??
+        `trace-root-${observation.trace_id}`,
+      name: observation.name ?? "sample_name",
+      type: observation.type,
+      environment: observation.environment,
+      metadata: observation.metadata,
+      level: observation.level ?? "DEFAULT",
+      status_message: observation.status_message,
+      version: observation.version,
+      input: observation.input,
+      output: observation.output,
+      provided_model_name: observation.provided_model_name,
+      model_id: observation.internal_model_id,
+      model_parameters: observation.model_parameters,
+      total_cost: observation.total_cost,
+      prompt_id: observation.prompt_id,
+      prompt_name: observation.prompt_name,
+      prompt_version: observation.prompt_version,
+      provided_usage_details: observation.provided_usage_details,
+      provided_cost_details: observation.provided_cost_details,
+      usage_details: observation.usage_details,
+      cost_details: observation.cost_details,
+      tool_definitions: observation.tool_definitions,
+      tool_calls: observation.tool_calls,
+      tool_call_names: observation.tool_call_names,
+      start_time: observation.start_time,
+      end_time: observation.end_time,
+      completion_start_time: observation.completion_start_time,
+      created_at: observation.created_at,
+      updated_at: observation.updated_at,
+      event_ts: observation.event_ts,
+    }),
+  );
+
+  return await streamLoad("events_full", values);
+};
+
+const createScoresCh = async (scores: ScoreRecordInsertType[]) =>
+  await streamLoad("scores", scores);
+
+const createEventsCh = async (events: EventRecordInsertType[]) =>
+  await streamLoad(
+    "events_full",
+    events.map((event) => normalizeEventRecordTimestamps(event)),
+  );
 
 describe("BlobStorageIntegrationProcessingJob", () => {
   let storageService: StorageService;
@@ -97,6 +226,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           env.LITEFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
         enabled: false,
         exportFrequency: "hourly",
+        compressed: false,
       },
     });
 
@@ -137,6 +267,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           exportSource: "TRACES_OBSERVATIONS_EVENTS",
           nextSyncAt: twoHoursAgo,
           lastSyncAt: twoHoursAgo,
+          compressed: false,
         },
       });
 
@@ -282,6 +413,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           enabled: true,
           exportFrequency: "weekly",
           lastSyncAt: oneHourAgo,
+          compressed: false,
         },
       });
 
@@ -348,6 +480,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           enabled: true,
           exportFrequency: "daily",
           lastSyncAt: oneHourAgo,
+          compressed: false,
         },
       });
 
@@ -442,6 +575,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
             prefix,
             fileType,
             lastSyncAt: oneHourAgo,
+            compressed: false,
           },
           create: {
             projectId,
@@ -459,6 +593,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
             exportSource: "TRACES_OBSERVATIONS_EVENTS",
             fileType,
             lastSyncAt: oneHourAgo,
+            compressed: false,
           },
         });
 
@@ -563,6 +698,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
             exportMode: "FULL_HISTORY",
             exportStartDate: null,
             lastSyncAt: null, // First export
+            compressed: false,
           },
         });
 
@@ -639,6 +775,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           exportMode: "FROM_TODAY" as any,
           exportStartDate: new Date(), // Use current date
           lastSyncAt: null, // First export
+          compressed: false,
         },
       });
 
@@ -702,6 +839,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           exportMode: "FROM_CUSTOM_DATE" as any,
           exportStartDate: customDate,
           lastSyncAt: null, // First export
+          compressed: false,
         },
       });
 
@@ -761,6 +899,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
             exportMode: "FULL_HISTORY",
             exportStartDate: null,
             lastSyncAt: null,
+            compressed: false,
           },
         });
 
@@ -837,6 +976,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           enabled: true,
           exportFrequency: "hourly",
           lastSyncAt: twoDaysAgo, // Start from 2 days ago
+          compressed: false,
         },
       });
 
@@ -894,6 +1034,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           enabled: true,
           exportFrequency: "hourly",
           lastSyncAt: oneHourAgo,
+          compressed: false,
         },
       });
 

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1,5 +1,6 @@
 import { pipeline } from "stream";
 import { Job } from "bullmq";
+import { createGzip } from "node:zlib";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   QueueName,
@@ -21,6 +22,8 @@ import {
   BlobStorageIntegrationType,
   BlobStorageIntegrationFileType,
   BlobStorageExportMode,
+  DEFAULT_OBSERVATION_FIELD_GROUPS,
+  type ObservationFieldGroup,
 } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { randomUUID } from "crypto";
@@ -117,29 +120,122 @@ const getFrequencyIntervalMs = (frequency: string): number => {
   }
 };
 
-const getFileTypeProperties = (fileType: BlobStorageIntegrationFileType) => {
+const OBSERVATION_FIELD_GROUP_COLUMNS: Record<
+  ObservationFieldGroup,
+  readonly string[]
+> = {
+  core: [
+    "id",
+    "trace_id",
+    "project_id",
+    "type",
+    "parent_observation_id",
+    "start_time",
+    "end_time",
+  ],
+  basic: [
+    "name",
+    "level",
+    "status_message",
+    "version",
+    "environment",
+    "user_id",
+    "session_id",
+    "trace_name",
+    "tags",
+    "release",
+    "event_version",
+    "bookmarked",
+    "public",
+  ],
+  time: ["completion_start_time", "created_at", "updated_at"],
+  io: ["input", "output"],
+  metadata: ["metadata", "metadata_names", "metadata_values"],
+  model: ["model", "provided_model_name", "model_parameters"],
+  usage: ["usage_details", "cost_details", "total_cost"],
+  prompt: ["prompt_id", "prompt_name", "prompt_version"],
+  metrics: ["latency", "time_to_first_token"],
+};
+
+const getFileTypeProperties = (
+  fileType: BlobStorageIntegrationFileType,
+  compressed: boolean,
+) => {
+  let baseProperties: { contentType: string; extension: string };
+
   switch (fileType) {
     case BlobStorageIntegrationFileType.JSON:
-      return {
+      baseProperties = {
         contentType: "application/json; charset=utf-8",
         extension: "json",
       };
+      break;
     case BlobStorageIntegrationFileType.CSV:
-      return {
+      baseProperties = {
         contentType: "text/csv; charset=utf-8",
         extension: "csv",
       };
+      break;
     case BlobStorageIntegrationFileType.JSONL:
-      return {
+      baseProperties = {
         contentType: "application/x-ndjson; charset=utf-8",
         extension: "jsonl",
       };
+      break;
     default:
       // eslint-disable-next-line no-case-declarations
       const _exhaustiveCheck: never = fileType;
       throw new Error(`Unsupported file type: ${fileType}`);
   }
+
+  return compressed
+    ? {
+        contentType: "application/gzip",
+        extension: `${baseProperties.extension}.gz`,
+      }
+    : baseProperties;
 };
+
+const isObservationExportTable = (
+  table: "traces" | "observations" | "scores" | "observations_v2",
+): table is "observations" | "observations_v2" =>
+  table === "observations" || table === "observations_v2";
+
+const filterObservationBlobExportRow = (
+  row: Record<string, unknown>,
+  exportFieldGroups: ObservationFieldGroup[],
+) => {
+  const allowedColumns = new Set<string>();
+
+  for (const group of exportFieldGroups) {
+    for (const column of OBSERVATION_FIELD_GROUP_COLUMNS[group]) {
+      allowedColumns.add(column);
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(row).filter(
+      ([key, value]) => allowedColumns.has(key) && value !== undefined,
+    ),
+  );
+};
+
+async function* applyObservationFieldSelection(params: {
+  rows: AsyncGenerator<Record<string, unknown>>;
+  table: "traces" | "observations" | "scores" | "observations_v2";
+  exportFieldGroups: ObservationFieldGroup[];
+}) {
+  const exportFieldGroups =
+    params.exportFieldGroups.length > 0
+      ? params.exportFieldGroups
+      : DEFAULT_OBSERVATION_FIELD_GROUPS;
+
+  for await (const row of params.rows) {
+    yield isObservationExportTable(params.table)
+      ? filterObservationBlobExportRow(row, exportFieldGroups)
+      : row;
+  }
+}
 
 const processBlobStorageExport = async (config: {
   projectId: string;
@@ -155,6 +251,8 @@ const processBlobStorageExport = async (config: {
   type: BlobStorageIntegrationType;
   table: "traces" | "observations" | "scores" | "observations_v2"; // observations_v2 is the events table
   fileType: BlobStorageIntegrationFileType;
+  compressed: boolean;
+  exportFieldGroups: ObservationFieldGroup[];
 }) => {
   logger.info(
     `[BLOB INTEGRATION] Processing ${config.table} export for project ${config.projectId}`,
@@ -175,7 +273,10 @@ const processBlobStorageExport = async (config: {
   });
 
   try {
-    const blobStorageProps = getFileTypeProperties(config.fileType);
+    const blobStorageProps = getFileTypeProperties(
+      config.fileType,
+      config.compressed,
+    );
 
     // Create the file path with prefix if available
     const timestamp = config.maxTimestamp
@@ -220,18 +321,38 @@ const processBlobStorageExport = async (config: {
         throw new Error(`Unsupported table type: ${config.table}`);
     }
 
-    const fileStream = pipeline(
-      dataStream,
-      streamTransformations[config.fileType](),
-      (err) => {
-        if (err) {
-          logger.error(
-            "[BLOB INTEGRATION] Getting data from DB for blob storage integration failed: ",
-            err,
-          );
-        }
-      },
-    );
+    const filteredDataStream = applyObservationFieldSelection({
+      rows: dataStream,
+      table: config.table,
+      exportFieldGroups: config.exportFieldGroups,
+    });
+
+    const fileStream = config.compressed
+      ? pipeline(
+          filteredDataStream,
+          streamTransformations[config.fileType](),
+          createGzip(),
+          (err) => {
+            if (err) {
+              logger.error(
+                "[BLOB INTEGRATION] Getting data from DB for blob storage integration failed: ",
+                err,
+              );
+            }
+          },
+        )
+      : pipeline(
+          filteredDataStream,
+          streamTransformations[config.fileType](),
+          (err) => {
+            if (err) {
+              logger.error(
+                "[BLOB INTEGRATION] Getting data from DB for blob storage integration failed: ",
+                err,
+              );
+            }
+          },
+        );
 
     // Upload the file to cloud storage
     // For CSV exports, use larger part size to handle big files
@@ -359,6 +480,12 @@ export const handleBlobStorageIntegrationProjectJob = async (
       forcePathStyle: blobStorageIntegration.forcePathStyle || undefined,
       type: blobStorageIntegration.type,
       fileType: blobStorageIntegration.fileType,
+      compressed: blobStorageIntegration.compressed,
+      exportFieldGroups:
+        (blobStorageIntegration.exportFieldGroups as
+          | ObservationFieldGroup[]
+          | null
+          | undefined) ?? DEFAULT_OBSERVATION_FIELD_GROUPS,
     };
 
     // Check if this project should only export traces (legacy behavior via env var)


### PR DESCRIPTION
…controls

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Summary

This PR extends blob storage integrations so exports can be configured more precisely and handled more safely end-to-end.

### What changed

- add `export_field_groups` and `compressed` to `BlobStorageIntegration` with a Prisma migration
- introduce shared observation field group definitions and defaults
- centralize blob storage integration upsert logic into a dedicated service
- add validation for export field groups and Azure container naming
- extend blob storage API contracts and Fern definitions for:
  - export source
  - export field groups
  - gzip compression
- update the project settings UI to configure:
  - export source
  - export field groups
  - gzip compression
- update background blob export handling to honor selected field groups and compression
- update observations/events export shaping to support smaller, targeted payloads
- add regression coverage for API and worker export behavior

## Impacted Packages

- `packages/shared`
- `web`
- `worker`
- `fern`

## Verification

- `TEST_PORT=41000 pnpm exec dotenv -e ../.env.test -e ../.env -- jest --verbose --runInBand --selectProjects server --testPathPatterns='blob-storage-integration-status-api.servertest.ts' --testTimeout=120000`
- `TEST_PORT=41000 pnpm exec dotenv -e ../.env.test -e ../.env -- jest --verbose --runInBand --selectProjects server --testPathPatterns='blob-storage-integration-api.servertest.ts' --testTimeout=120000`
- `TEST_DORIS_STREAM_LOAD_URL=http://127.0.0.1:42840 DORIS_FE_HTTP_URL=http://127.0.0.1:42830 DORIS_FE_QUERY_PORT=42930 DORIS_DB=langfuse DORIS_USER=root pnpm exec dotenv -e ../.env.test -e ../.env -- vitest run src/__tests__/blobStorageIntegrationProcessing.test.ts --testTimeout=120000`

## Notes

- Current fork keeps the background export coverage in `worker/src/__tests__/blobStorageIntegrationProcessing.test.ts` instead of the `web` pg-boss test path used in `selectdb/litefuse`.
- Prisma generated types are included with the schema change.
- Fern source definitions were updated for the public API contract change.

<!-- Please provide a loom video for visual changes to speed up reviews
Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/selectdb/langfuse-doris/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
