### PR TITLE
fix: add trace context blob export mapping

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -155,6 +155,7 @@ const OBSERVATION_FIELD_GROUP_COLUMNS: Record<
   usage: ["usage_details", "cost_details", "total_cost"],
   prompt: ["prompt_id", "prompt_name", "prompt_version"],
   metrics: ["latency", "time_to_first_token"],
+  trace_context: ["trace_name", "tags", "release"],
 };
 
 const getFileTypeProperties = (


### PR DESCRIPTION
## Summary\n- add the missing trace_context column mapping for blob storage observation exports\n- fixes worker TypeScript build after trace_context was added to ObservationFieldGroup\n\n## Verification\n- pnpm turbo run build --filter=worker...