### PR TITLE
fix(doris): rewrite metadata access and events traces API filters

### DIFF
--- a/packages/shared/src/server/doris/__tests__/client.streamLoad.unit.test.ts
+++ b/packages/shared/src/server/doris/__tests__/client.streamLoad.unit.test.ts
@@ -290,4 +290,46 @@ describe("DorisClient.streamLoad — FE→BE redirect connection reuse", () => {
     );
     expect(beHits).toBe(3);
   });
+
+  it("caps exponential backoff at 60 seconds", async () => {
+    vi.useFakeTimers();
+    try {
+      client = new DorisClient({
+        feHttpUrl: `http://127.0.0.1:${fe.port}`,
+        database: "langfuse",
+        username: "admin",
+        password: "secret",
+        timeout: 5000,
+        maxRetries: 3,
+        retryDelay: 40_000,
+        maxSockets: 8,
+      });
+
+      const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+      const streamLoadSpy = vi
+        .spyOn(client, "streamLoad")
+        .mockRejectedValue(new Error("bad gateway"));
+
+      const insertPromise = client.insert("traces", [{ id: "x" }]);
+      const rejectionExpectation = expect(insertPromise).rejects.toThrowError(
+        /Stream load failed after 3 attempts/,
+      );
+
+      await vi.runAllTimersAsync();
+      await rejectionExpectation;
+
+      const retryDelays = setTimeoutSpy.mock.calls
+        .map(([, delay]) => delay)
+        .filter(
+          (delay): delay is number =>
+            typeof delay === "number" &&
+            [40_000, 60_000, 80_000].includes(delay),
+        );
+
+      expect(streamLoadSpy).toHaveBeenCalledTimes(3);
+      expect(retryDelays).toEqual([40_000, 60_000]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/shared/src/server/doris/client.ts
+++ b/packages/shared/src/server/doris/client.ts
@@ -42,6 +42,7 @@ export interface DorisClientConfig {
   timeout?: number;
   maxRetries?: number;
   retryDelay?: number;
+  maxRetryDelay?: number;
   headers?: Record<string, string>;
   maxOpenConnections?: number;
   maxSockets?: number;
@@ -54,6 +55,7 @@ export type DorisClientType = DorisClient;
  * Focuses on Stream Load functionality for high-performance data ingestion and MySQL protocol for queries
  */
 export class DorisClient {
+  private static readonly DEFAULT_STREAM_LOAD_MAX_RETRY_DELAY_MS = 60_000;
   private httpClient: AxiosInstance;
   // Dedicated instance for Stream Load PUTs. Shares agents + interceptors with
   // httpClient but omits the instance-level `auth` config — Stream Load callers
@@ -79,6 +81,9 @@ export class DorisClient {
       maxRetries:
         config.maxRetries ?? env.LITEFUSE_INGESTION_DORIS_MAX_ATTEMPTS ?? 3,
       retryDelay: config.retryDelay ?? 1000,
+      maxRetryDelay:
+        config.maxRetryDelay ??
+        DorisClient.DEFAULT_STREAM_LOAD_MAX_RETRY_DELAY_MS,
       headers: config.headers || {},
       maxOpenConnections:
         config.maxOpenConnections ?? env.DORIS_MAX_OPEN_CONNECTIONS,
@@ -705,7 +710,10 @@ export class DorisClient {
         lastError = error instanceof Error ? error : new Error(String(error));
 
         if (attempt < this.config.maxRetries) {
-          const delay = this.config.retryDelay * Math.pow(2, attempt - 1); // Exponential backoff
+          const delay = Math.min(
+            this.config.retryDelay * Math.pow(2, attempt - 1),
+            this.config.maxRetryDelay,
+          );
           logger.warn(
             `Stream load attempt ${attempt} failed for ${table}, retrying in ${delay}ms: ${lastError.message}`,
           );


### PR DESCRIPTION
## Summary
- cap Doris stream load retry backoff at 1 minute
- rewrite Doris `events_full` metadata filters from legacy `metadata['key']` access to `element_at(metadata_values, array_position(metadata_names, 'key'))`
- apply the shared Doris metadata filter builder to the `useEventsTable=true` public traces API rows/count queries so metadata and time predicates are honored consistently
- normalize Doris array/decimal response fields on the events traces API path (`observations`, `scores`, `totalCost`, `latency`)
- keep non-`events_full` metadata access on MAP-backed tables unchanged

## Verification
- `pnpm --filter @langfuse/shared run typecheck`
- `pnpm --filter worker run typecheck`
- `pnpm --filter web run test --testPathPatterns=queryBuilder-doris-metadata.servertest.ts`
- live OTel ingestion to `http://localhost:41000/api/public/otel/v1/traces` with the provided project keys
- live API query against a local web server on `http://localhost:41001/api/public/traces?useEventsTable=true...` returning only the matching trace
- inspected the live Doris SQL and confirmed it uses `element_at(t.metadata_values, array_position(t.metadata_names, ...))` in both rows and count queries

## Live Repro Notes
- ingested traces: `11111111111111111111111198507458` (`metadata-array-test-1`) and `22222222222222222222222298507458` (`metadata-array-test-2`)
- direct Doris check on `events_full` confirmed `resourceAttributes.service.name` was flattened into `metadata_names` / `metadata_values`
- `docker logs litefuse-doris-web` on the stock container still does not print successful Doris SQL because `LITEFUSE_DORIS_LOG_QUERIES` is not enabled there; SQL logging was verified via the local `41001` web process with that flag turned on