### PR TITLE
fix(ui): restore dismissible drawer default

### DIFF
--- a/web/src/features/comments/CommentDrawerButton.clienttest.tsx
+++ b/web/src/features/comments/CommentDrawerButton.clienttest.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { CommentDrawerButton } from "./CommentDrawerButton";
+
+const mockOnOpenChange = jest.fn();
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    query: {},
+    asPath: "/",
+    pathname: "/",
+    replace: jest.fn(),
+  }),
+}));
+
+jest.mock("../rbac/utils/checkProjectAccess", () => ({
+  useHasProjectAccess: () => true,
+}));
+
+jest.mock("../../components/layouts/header", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("./CommentList", () => ({
+  CommentList: () => <div>Comment list</div>,
+}));
+
+jest.mock("../../components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+jest.mock("../../components/ui/drawer", () => ({
+  Drawer: ({
+    children,
+    dismissible,
+    onOpenChange,
+  }: {
+    children: ReactNode;
+    dismissible?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <div data-testid="comments-drawer" data-dismissible={String(dismissible)}>
+      <button type="button" onClick={() => onOpenChange?.(false)}>
+        Dismiss drawer
+      </button>
+      {children}
+    </div>
+  ),
+  DrawerContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DrawerClose: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DrawerHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DrawerTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DrawerTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe("CommentDrawerButton", () => {
+  beforeEach(() => {
+    mockOnOpenChange.mockReset();
+  });
+
+  it("allows the comments drawer to be dismissed", () => {
+    render(
+      <CommentDrawerButton
+        projectId="project-1"
+        objectId="trace-1"
+        objectType="TRACE"
+        isOpen
+        onOpenChange={mockOnOpenChange}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("comments-drawer").getAttribute("data-dismissible"),
+    ).toBe("true");
+    expect(screen.getByRole("button", { name: "Close comments" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss drawer" }));
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/src/features/comments/CommentDrawerButton.tsx
+++ b/web/src/features/comments/CommentDrawerButton.tsx
@@ -2,6 +2,7 @@ import Header from "@/src/components/layouts/header";
 import { Button, type ButtonProps } from "@/src/components/ui/button";
 import {
   Drawer,
+  DrawerClose,
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
@@ -10,7 +11,7 @@ import {
 import { CommentList } from "@/src/features/comments/CommentList";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { type CommentObjectType } from "@langfuse/shared";
-import { MessageCircleIcon, MessageCircleOff } from "lucide-react";
+import { MessageCircleIcon, MessageCircleOff, X } from "lucide-react";
 import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { type SelectionData } from "./contexts/InlineCommentSelectionContext";
@@ -124,6 +125,7 @@ export function CommentDrawerButton({
   return (
     <Drawer
       open={isDrawerOpen}
+      dismissible
       onOpenChange={(open) => {
         // Prevent drawer from closing when mention dropdown is open
         if (!open && isMentionDropdownOpen) {
@@ -197,6 +199,17 @@ export function CommentDrawerButton({
               <Header title="Comments"></Header>
             </DrawerTitle>
           </DrawerHeader>
+          <DrawerClose asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="absolute top-2 right-2 z-10"
+              aria-label="Close comments"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </DrawerClose>
           <div data-vaul-no-drag className="min-h-0 flex-1 px-2 pt-2">
             <CommentList
               projectId={projectId}


### PR DESCRIPTION
## Summary
- restore the shared Drawer default so side drawers can close by overlay click or Escape
- retain explicit per-drawer overrides for flows that must prevent dismissal
- add a regression test for the shared Drawer default
- include an explicit close button for comments

## Impacted packages
- web

## Verification
- pnpm --filter web run test-client --testPathPatterns="(drawer|CommentDrawerButton).clienttest.tsx"
- pnpm --filter web exec dotenv -e ../.env -- eslint src/components/ui/drawer.tsx src/components/ui/drawer.clienttest.tsx src/features/comments/CommentDrawerButton.tsx src/features/comments/CommentDrawerButton.clienttest.tsx --no-cache --max-warnings 0