### PR TITLE
fix(ui): restore dismissible drawer default

### DIFF
--- a/web/src/components/ui/drawer.clienttest.tsx
+++ b/web/src/components/ui/drawer.clienttest.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { Drawer } from "./drawer";
+
+type DrawerRootProps = {
+  children?: ReactNode;
+  dismissible?: boolean;
+};
+
+jest.mock("react-responsive", () => ({
+  useMediaQuery: () => false,
+}));
+
+jest.mock("vaul", () => ({
+  Drawer: {
+    Root: ({ children, dismissible }: DrawerRootProps) => (
+      <div data-testid="drawer-root" data-dismissible={String(dismissible)}>
+        {children}
+      </div>
+    ),
+    Trigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    Portal: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    Overlay: () => null,
+    Content: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    Close: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    Title: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    Description: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  },
+}));
+
+describe("Drawer", () => {
+  it("is dismissible by default", () => {
+    render(<Drawer>Drawer content</Drawer>);
+
+    expect(
+      screen.getByTestId("drawer-root").getAttribute("data-dismissible"),
+    ).toBe("true");
+  });
+});

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -77,7 +77,7 @@ const useDrawerContext = () => React.useContext(DrawerContext);
 
 const Drawer = ({
   shouldScaleBackground = true,
-  dismissible = false,
+  dismissible = true,
   forceDirection = "responsive",
   blockTextSelection = false,
   ...props


### PR DESCRIPTION
## Summary
- restore the shared Drawer default so side drawers can close by overlay click or Escape
- retain explicit per-drawer overrides for flows that must prevent dismissal
- add a regression test for the shared Drawer default

## Impacted packages
- web

## Verification
- pnpm --filter web run test-client --testPathPatterns="drawer.clienttest.tsx"
- pnpm --filter web exec dotenv -e ../.env -- eslint src/components/ui/drawer.tsx src/components/ui/drawer.clienttest.tsx --no-cache --max-warnings 0