### PR TITLE
fix(shared): preserve inclusive OpenAI token usage totals

### DIFF
--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -141,7 +141,6 @@ const OpenAICompletionUsageSchema = z
       for (const [key, value] of Object.entries(prompt_tokens_details)) {
         if (value !== null && value !== undefined) {
           result[`input_${key}`] = value;
-          result.input = Math.max(result.input - (value ?? 0), 0);
         }
       }
     }
@@ -150,7 +149,6 @@ const OpenAICompletionUsageSchema = z
       for (const [key, value] of Object.entries(completion_tokens_details)) {
         if (value !== null && value !== undefined) {
           result[`output_${key}`] = value;
-          result.output = Math.max(result.output - (value ?? 0), 0);
         }
       }
     }
@@ -196,7 +194,6 @@ const OpenAIResponseUsageSchema = z
       for (const [key, value] of Object.entries(input_tokens_details)) {
         if (value !== null && value !== undefined) {
           result[`input_${key}`] = value;
-          result.input = Math.max(result.input - (value ?? 0), 0);
         }
       }
     }
@@ -205,7 +202,6 @@ const OpenAIResponseUsageSchema = z
       for (const [key, value] of Object.entries(output_tokens_details)) {
         if (value !== null && value !== undefined) {
           result[`output_${key}`] = value;
-          result.output = Math.max(result.output - (value ?? 0), 0);
         }
       }
     }

--- a/packages/shared/src/server/ingestion/types.unit.test.ts
+++ b/packages/shared/src/server/ingestion/types.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { UsageDetails } from "./types";
+
+describe("UsageDetails", () => {
+  it("preserves inclusive OpenAI prompt and completion totals with token details", () => {
+    const result = UsageDetails.parse({
+      prompt_tokens: 67,
+      completion_tokens: 18,
+      total_tokens: 85,
+      prompt_tokens_details: {
+        cached_tokens: 0,
+        text_tokens: 67,
+      },
+      completion_tokens_details: {
+        reasoning_tokens: 16,
+        text_tokens: 18,
+      },
+    });
+
+    expect(result).toEqual({
+      input: 67,
+      output: 18,
+      total: 85,
+      input_cached_tokens: 0,
+      input_text_tokens: 67,
+      output_reasoning_tokens: 16,
+      output_text_tokens: 18,
+    });
+  });
+
+  it("preserves inclusive OpenAI Response API totals with token details", () => {
+    const result = UsageDetails.parse({
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      input_tokens_details: {
+        text_tokens: 80,
+        image_tokens: 20,
+      },
+      output_tokens_details: {
+        reasoning_tokens: 40,
+        text_tokens: 50,
+      },
+    });
+
+    expect(result).toEqual({
+      input: 100,
+      output: 50,
+      total: 150,
+      input_text_tokens: 80,
+      input_image_tokens: 20,
+      output_reasoning_tokens: 40,
+      output_text_tokens: 50,
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

OpenAI token detail objects are breakdowns of the inclusive totals. The ingestion transforms currently subtract every detail value, which can turn normal usage into `input: 0` and `output: 0` and affect usage and cost reporting.

This change:
- preserves inclusive OpenAI prompt/completion token totals during ingestion
- preserves inclusive Responses API input/output token totals
- continues exposing token-detail breakdown fields without subtracting them
- adds focused regression coverage for both usage shapes

No dependencies are added and no documentation or public API changes are required.

Fixes #61

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Impacted packages

- `@langfuse/shared`

## Verification

- `pnpm --dir packages/shared exec vitest run --config vitest.config.ts src/server/ingestion/types.unit.test.ts` — 2 passed
- targeted ESLint for `types.unit.test.ts` — passed
- `git diff --check upstream/main...HEAD` — passed
- regression sabotage run with the old subtraction restored — 2 expected failures; restoring the fix returned 2 passes
- independent diff review — passed with no blocking or security findings

## Verification notes

- Full shared lint is currently dominated by pre-existing CRLF/Prettier warnings in `types.ts` (826 warnings, 0 errors in the touched source file), so this PR intentionally avoids unrelated line-ending churn.
- Broader shared typecheck/web/worker checks require generated Prisma outputs or environment configuration unavailable in the bounded local setup; focused schema tests pass.
- Local focused tests ran on Node 22.23.2; the repository declares Node 24, so CI is the canonical runtime verification.